### PR TITLE
Restoring the "Remove Jungle" tile improvement

### DIFF
--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -165,11 +165,19 @@
 	{
 		"name": "Remove Forest",
 		"turnsToBuild": 4,
-		"terrainsCanBeBuiltOn": ["Forest","Jungle"],
+		"terrainsCanBeBuiltOn": ["Forest"],
 		"techRequired": "Mining",
 		"uniques": ["Can be built outside your borders"],
 		"shortcutKey": "X",
 		"civilopediaText": [{text:"Provides a one-time Production bonus depending on distance to the closest city once finished"}]
+	},
+	{
+		"name": "Remove Jungle",
+		"turnsToBuild": 7,
+		"terrainsCanBeBuiltOn": ["Jungle"],
+		"techRequired": "Bronze Working",
+		"uniques": ["Can be built outside your borders"],
+		"shortcutKey": "X"
 	},
 	{
 		"name": "Remove Fallout",


### PR DESCRIPTION
The "Remove Forest" tile improvement doesn't actually remove any jungles even when the improvement can be built on jungles. This is a bit of an issue since there are resources sometimes generate on jungles, potentially making them unworkable.