### PR TITLE
Update UnitPromotions.json

### DIFF
--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -748,7 +748,7 @@
 	},
 		{
 		"name": "Zuverlässigkeit",
-		"uniques": ["Unit will heal every turn, even if it performs an action","Great General provides double combat bonus"],
+		"uniques": ["Unit will heal every turn, even if it performs an action","[+15]% Strength when stacked with [Great General]"],
 		"prerequisites": ["Zielstrebigkei"],
 		"unitTypes": ["Melee","Mounted","Scout","Siege","Ranged", "Mounted Ranged","Armor","Armored","Gunpowder"]
 	},


### PR DESCRIPTION
Should fix the the following error: ""Great General provides double combat bonus" cannot be put on this type of object!".