### PR TITLE
Update Nations.json

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -2289,7 +2289,7 @@
 		"outerColor": [255,247,241],
 		"innerColor": [116,55,25],
 		"uniqueName": "Iklwa",
-		"uniques": ["[-50]% maintenance costs <for [Melee] units>","[33]% XP gained from combat <for [Military] units>"],
+		"uniques": ["[-50]% maintenance costs <for [Melee] units>","[50]% XP gained from combat <for [Military] units>"],
 		"cities": ["Ulundi","Umgungundlovu","Bulawayo","KwaDukuza","Nongoma","oNdini","Nodwengu","Ndonakusuka","Babanango","Khangela",
 			"KwaHlomendlini","Hlobane","eThekwini","Mlambongwenya","Eziqwaqweni","Isiphezi","Masotsheni","Mtunzini","Nyakamubi","Dumazulu",
 			"Hlatikulu","Mthonjaneni","Empangeni","Pongola","Tugela","Kwamashu","Ingwavuma","Hlulhluwe","Matubatuba","Mhlahlandlela",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -2289,7 +2289,7 @@
 		"outerColor": [255,247,241],
 		"innerColor": [116,55,25],
 		"uniqueName": "Iklwa",
-		"uniques": ["[-50]% maintenance costs <for [Melee] units>","[25]% XP gained from combat <for [Military] units>"],
+		"uniques": ["[-50]% maintenance costs <for [Melee] units>","[33]% XP gained from combat <for [Military] units>"],
 		"cities": ["Ulundi","Umgungundlovu","Bulawayo","KwaDukuza","Nongoma","oNdini","Nodwengu","Ndonakusuka","Babanango","Khangela",
 			"KwaHlomendlini","Hlobane","eThekwini","Mlambongwenya","Eziqwaqweni","Isiphezi","Masotsheni","Mtunzini","Nyakamubi","Dumazulu",
 			"Hlatikulu","Mthonjaneni","Empangeni","Pongola","Tugela","Kwamashu","Ingwavuma","Hlulhluwe","Matubatuba","Mhlahlandlela",


### PR DESCRIPTION
Originally, Zulu requires 25% less XP to promote. That is;
> -25% = ×0.75 = ×3/4.

Say G is XP gain and P is promotion hurdle, and we can say for Zulu;
> G = P×3/4

It's impossible to cut off XP hurdle.
Giving boost on XP gain is the best alternatives.
But that means;
> G×4/3 = P

> ×4/3 = ×1.33 = +33%

Thus Zulu's XP boost is +33%, not +25%.