### PR TITLE
Remove dummy buildings

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -502,7 +502,7 @@
         "gold": 5,
         "greatPersonPoints": {"Great Merchant": 1},
         "isWonder": true,
-        "uniques": ["Must be next to [Coast]","Provides [1] [Trade Route]","Provides [1] [Trade Route (Count)]","Free [Cargo Ship] appears","[+2 Gold] from [Sea Trade Route(Gold)] tiles [in this city]"],
+        "uniques": ["Must be next to [Coast]","Provides [1] [Trade Route]","Provides [1] [Trade Route (Count)]","Free [Cargo Ship] appears","[+2 Gold] from [Sea Trade Route (Gold)] tiles [in this city]"],
         "requiredTech": "Iron Working",
         "quote": "'Why man, he doth bestride the narrow world like a colossus, and we petty men walk under his huge legs, and peep about to find ourselves dishonorable graves.' - William Shakespeare, Julius Caesar"
     },
@@ -1087,7 +1087,7 @@
         "isNationalWonder": true,
         "uniques": ["Provides [2] [Trade Route (Count)]","Provides [2] [Trade Route]",
             "[+4 Gold] from every [Land Trade Route (Gold)]","[+4 Gold] from every [Sea Trade Route (Gold)]", "[+25]% [Gold] [in this city]"],
-        "requiredTech": "Curr"
+        "requiredTech": "Currency"
     },
     {
         "name": "Artist Guild", 
@@ -1677,7 +1677,7 @@
         "culture": 1,
         "greatPersonPoints": {"Great Scientist": 2},
         "isWonder": true,
-        "uniques": ["[+3 Science, +3 Culture] from [Luxury resource] tiles [in this city]", ,"Only available <after adopting [Rationalism]>"],
+        "uniques": ["[+3 Science, +3 Culture] from [Luxury resource] tiles [in this city]","Only available <after adopting [Rationalism]>"],
         "requiredTech": "Architecture",
         "quote": "'Things always seem fairer when we look back at them, and it is out of that inaccessible tower of the past that Longing leans and beckons.'  - James Russell Lowell"
     }, 

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -54,6 +54,10 @@
 		"happiness": 1,
 		"uniques": ["Unbuildable","[+1 Faith, +1 Culture] from [Luxury resource] tiles [in this city]"]
 	},
+	  {
+	    "name": "Monastery",
+	    "uniques": ["[+1 Faith, +1 Culture] from [Incense] tiles [in this city]", "[+1 Faith, +1 Culture] from [Wine] tiles [in this city]", "[+1 Culture, +1 Faith] from [Perfume] tiles [in this city]", "Unbuildable"]
+	  },
     {
         "name": "~limit",
 	    "gold": 2,
@@ -87,11 +91,19 @@
         "uniques": ["Unsellable","Will not be displayed in Civilopedia","Unbuildable","Destroyed when the city is captured"]
     },
 	    {
+        "name": "Watch Tower",
+        "cityStrength": 7,
+        "cityHealth": 50,
+        "hurryCostModifier": 25,
+        "requiredTech": "Masonry",
+		"uniques": ["Unbuildable"]
+    },
+	    {
         "name": "Castle Builders",
         "cityStrength": 5,
 		    "cost": 1,
 		    "uniqueTo": "Normandy",
-        "uniques": ["Unsellable","Unbuildable","Will not be displayed in Civilopedia"]
+        "uniques": ["Unsellable","Unbuildable"]
     },
 		    {
         "name": "Ulugh Beg's Observatory",
@@ -100,7 +112,7 @@
 		    "isNationalWonder": true,
 		    "percentStatBonus": {"science": 10, "production": 10, "gold": 10, "culture": 10},
 		    "cost": 1,
-        "uniques": ["Unbuildable","Will not be displayed in Civilopedia"]
+        "uniques": ["Unbuildable"]
     },
 	
 	// Buildings & Wonders
@@ -114,9 +126,7 @@
 		"culture": 1,
 		"cityStrength": 2,
 		"cost": 1,
-		"uniques": ["Indicates the capital city","[-1 Gold] from every [River]","Double quantity of [Horses] produced","Double quantity of [Iron] produced",
-					"Double quantity of [Coal] produced","Double quantity of [Oil] produced",
-					"Double quantity of [Aluminum] produced","[-1 Culture] from every [Archaeological Dig]"]
+		"uniques": ["Indicates the capital city","[+2 Culture] <starting from the [Renaissance era]>"]
 	},
 	    {
         "name": "Orszaggyules",
@@ -129,7 +139,7 @@
         "cityStrength": 2,
         "culture": 1,
         "cost": 150,
-        "uniques": ["Indicates the capital city","[+25]% Great Person generation [in this city]","[+10]% Production when constructing [All] buildings [in this city]","Limited to [2] per Civilization"]
+        "uniques": ["Indicates the capital city","[+2 Culture] <starting from the [Renaissance era]>","[+25]% Great Person generation [in this city]","[+10]% Production when constructing [All] buildings [in this city]","Limited to [2] per Civilization"],
 	"requiredTech": "Mathematics",
     },
     {
@@ -146,16 +156,9 @@
 		"uniqueTo": "Maurya",
         "culture": 2,
         "cost": 20,
-        "hurryCostModifier": 40,
-		"uniques": ["Destroyed when the city is captured"]
-    },
-	    {
-        "name": "Shrine",
-        "faith": 1,
-        "cost": 40,
-        "hurryCostModifier": 40,
+        "hurryCostModifier": 40
 	"requiredTech": "Pottery",
-        "maintenance": 1
+		"uniques": ["Destroyed when the city is captured"]
     },
     {
         "name": "Stele", 
@@ -169,15 +172,12 @@
 		"uniques": ["Destroyed when the city is captured"]
     },
 	    {
-        "name": "Sauna", 
-        "replaces": "Monument",
-        "uniqueTo": "Finland",
-        "culture": 2,
+        "name": "Shrine",
+        "faith": 1,
         "cost": 40,
         "hurryCostModifier": 40,
-		"uniques": ["Destroyed when the city is captured","All newly-trained [relevant] units [in this city] receive the [Sauna] promotion","[+2 Culture] from [Oasis] tiles [in this city]","[+2 Culture] from [Lakes] tiles [in this city]"]
+	"requiredTech": "Pottery",
         "maintenance": 1
-		
     },
     {
         "name": "Pyramid", 
@@ -190,39 +190,48 @@
         "hurryCostModifier": 40,
         "maintenance": 1
     },
+	    {
+        "name": "Sauna", 
+        "replaces": "Shrine",
+        "uniqueTo": "Finland",
+        "faith": 1,
+        "cost": 40,
+        "hurryCostModifier": 40,
+        "requiredTech": "Pottery",
+		"uniques": ["All newly-trained [relevant] units [in this city] receive the [Sauna] promotion","[+2 Culture] from [Lakes] tiles [in this city]"]
+        "maintenance": 1
+		
+    },
     {
         "name": "Granary", 
         "food": 2,
         "maintenance": 1,
         "hurryCostModifier": 25,
         "uniques": ["[+1 Food] from [Deer] tiles [in this city]",
-			"[+1 Food] from [Bananas] tiles [in this city]",
-			"[+1 Food] from [Wheat] tiles [in this city]",
-		    	"[+1 Food] from [Maize] tiles [in this city]",
-		    		    "[+1 Food] from [Olives] tiles [in this city]",
+        "[+1 Food] from [Bananas] tiles [in this city]",
+			  "[+1 Food] from [Wheat] tiles [in this city]",
+		    "[+1 Food] from [Maize] tiles [in this city]",
+		    "[+1 Food] from [Olives] tiles [in this city]",
 		    "[+1 Food] from [Citrus] tiles [in this city]",
-		    "[+1 Food] from [Bison] tiles [in this city]",
-			"[+1 Food] from [Land Trade Route (Food)] tiles [in this city]",
-			"[+2 Food] from [Sea Trade Route (Food)] tiles [in this city]"],
+		    "[+1 Food] from [Bison] tiles [in this city]"],
         "requiredTech": "Pottery"
     },
 	    {
         "name": "Mala'e",
 		"replaces": "Granary",
 		"uniqueTo": "Tonga",
-        "food": 3,
+        "food": 4,
+        "faith": 2,
         "maintenance": 1,
 		"cost": 45,
         "hurryCostModifier": 25,
-        "uniques": ["[+1 Food] from [Land Trade Route (Food)] tiles [in this city]",
-			"[+2 Food] from [Sea Trade Route (Food)] tiles [in this city]"
-        	"[+1 Food] from [Deer] tiles [in this city]",
-			"[+1 Food] from [Bananas] tiles [in this city]",
+        "uniques": ["[+1 Food] from [Deer] tiles [in this city]",
+        "[+1 Food] from [Bananas] tiles [in this city]",
 		    "[+1 Food] from [Maize] tiles [in this city]",
 		    "[+1 Food] from [Olives] tiles [in this city]",
 		    "[+1 Food] from [Citrus] tiles [in this city]",
 		    "[+1 Food] from [Bison] tiles [in this city]",
-			"[+1 Food] from [Wheat] tiles [in this city]"],
+		    "[+1 Food] from [Wheat] tiles [in this city]"],
         "requiredTech": "Sailing"
     },
 	    {
@@ -230,7 +239,6 @@
 		"uniqueTo": "Bulgaria",
         "replaces": "Granary", 
         "food": 2,
-
         "maintenance": 1,
 		"cost": 54,
         "hurryCostModifier": 25,
@@ -238,7 +246,7 @@
 			"[+2 Food] from [Sea Trade Route (Food)] tiles [in this city]","[+1 Food] from [Deer] tiles [in this city]",
 			"[+1 Food] from [Bananas] tiles [in this city]",
 		    "[+1 Food] from [Maize] tiles [in this city]",
-		    		    "[+1 Food] from [Olives] tiles [in this city]",
+		    "[+1 Food] from [Olives] tiles [in this city]",
 		    "[+1 Food] from [Citrus] tiles [in this city]",
 		    "[+1 Food] from [Bison] tiles [in this city]",
 			"[+1 Food] from [Wheat] tiles [in this city]"],
@@ -321,15 +329,15 @@
         "specialistSlots": {"Artist": 1},
         "hurryCostModifier": 25,
         "maintenance": 1,
-		"culture": 1,
-		"science": 1,
+		    "culture": 3,
+		    "science": 1,
         "uniques": ["[+1 Science] per [2] population [in this city]","New [Military] units start with [15] Experience [in this city]"],
         "requiredTech": "Writing"
     },
     {
         "name": "The Great Library",
         "science": 3,
-        "culture": 1,
+        "culture": 5,
         "greatPersonPoints": {"Great Scientist": 1},
         "isWonder": true,
         "requiredTech": "Writing",
@@ -388,18 +396,10 @@
     {
         "name": "Walls",
         "cityStrength": 5,
-        "cityHealth": 50,
+        "cityHealth": 75,
         "hurryCostModifier": 25,
         "requiredTech": "Masonry",
 		"uniques": ["Destroyed when the city is captured"]
-    },
-	    {
-        "name": "Watch Tower",
-        "cityStrength": 7,
-        "cityHealth": 50,
-        "hurryCostModifier": 25,
-        "requiredTech": "Masonry",
-		"uniques": ["Unbuildable"]
     },
     {
         "name": "Walls of Babylon",
@@ -436,7 +436,7 @@
         "cityHealth": 50,
         "hurryCostModifier": 25,
         "requiredTech": "Masonry"
-		"uniques": ["Destroyed when the city is captured"]
+		"uniques": ["Destroyed when the city is captured", "[+1 Production] <after discovering [Metal Casting]>"]
     },
 		    {
         "name": "Lion's Gate",
@@ -485,16 +485,6 @@
         "maintenance": 1,
 		"uniques": ["Destroyed when the city is captured","New [Military] units start with [15] Experience [in this city]","All newly-trained [Melee] units [in this city] receive the [Buffalo Horns I] promotion"],
         "requiredTech": "Bronze Working"
-    }
-    {
-        "name": "Colossus",
-        "culture": 1,
-        "gold": 5,
-        "greatPersonPoints": {"Great Merchant": 1},
-        "isWonder": true,
-        "uniques": ["Must be next to [Coast]","Provides [1] [Trade Route]","Provides [1] [Trade Route (Count)]","Free [Cargo Ship] appears","[+1 Gold] from [Water] tiles [in this city]"],
-        "requiredTech": "Iron Working",
-        "quote": "'Why man, he doth bestride the narrow world like a colossus, and we petty men walk under his huge legs, and peep about to find ourselves dishonorable graves.' - William Shakespeare, Julius Caesar"
     },
     {
         "name": "Krepost",
@@ -507,9 +497,19 @@
         "requiredTech": "Bronze Working"
     },
     {
+        "name": "Colossus",
+        "culture": 1,
+        "gold": 5,
+        "greatPersonPoints": {"Great Merchant": 1},
+        "isWonder": true,
+        "uniques": ["Must be next to [Coast]","Provides [1] [Trade Route]","Provides [1] [Trade Route (Count)]","Free [Cargo Ship] appears","[+2 Gold] from [Sea Trade Route(Gold)] tiles [in this city]"],
+        "requiredTech": "Iron Working",
+        "quote": "'Why man, he doth bestride the narrow world like a colossus, and we petty men walk under his huge legs, and peep about to find ourselves dishonorable graves.' - William Shakespeare, Julius Caesar"
+    },
+    {
         "name": "Heroic Epic",
         "cost": 125,
-        "culture": 1,
+        "culture": 3,
         "isNationalWonder": true,
         "uniques": ["All newly-trained [non-air] units [in this city] receive the [Morale] promotion",
             "Cost increases by [30] per owned city","Requires a [Barracks] in all cities"],
@@ -541,7 +541,7 @@
         "name": "Lighthouse",
         "hurryCostModifier": 25,
         "maintenance": 1,
-        "uniques": ["Must be next to [Coast]","[+1 Food] from [Coast] tiles [in this city]","[+1 Food] from [Ocean] tiles [in this city]","[+1 Food] from [Fish] tiles [in this city]"],
+        "uniques": ["Must be next to [Coast]","[+1 Production] from [Water resource] tiles [in this city]","[+1 Food] from [Coast] tiles [in this city]","[+1 Food] from [Ocean] tiles [in this city]","[+1 Food] from [Fish] tiles [in this city]"],
         "requiredTech": "Optics"
     },
 	    {
@@ -553,7 +553,7 @@
 		"food": 1,
 		"gold": 1,
 		"production": 1,
-        "uniques": ["Must be next to [Coast]","[+1 Food] from [Coast] tiles [in this city]","[+1 Food] from [Ocean] tiles [in this city]","[+1 Food] from [Fish] tiles [in this city]"],
+        "uniques": ["Must be next to [Coast]","[+1 Production] from [Water resource] tiles [in this city]","[+1 Food] from [Coast] tiles [in this city]","[+1 Food] from [Ocean] tiles [in this city]","[+1 Food] from [Fish] tiles [in this city]"],
         "requiredTech": "Optics"
     },
     {
@@ -561,7 +561,7 @@
         "culture": 1,
         "greatPersonPoints": {"Great Merchant": 1},
         "isWonder": true,
-        "uniques": ["Gain a free [Lighthouse] [in this city]","Must be next to [Coast]", "[+1] Movement <for [{Military} {Water}] units>",
+        "uniques": ["Gain a free [Lighthouse] [in this city]","[+1 Gold] from [Water] tiles [in this city]","Must be next to [Coast]", "[+1] Movement <for [{Military} {Water}] units>", "Free [Quinquereme] appears",
 			"[+1] Sight <for [{Military} {Water}] units>"],
         "requiredTech": "Optics",
         "quote": "'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24"
@@ -609,11 +609,10 @@
         "name": "Ducal Stable", 
         "replaces": "Stable",
         "uniqueTo": "Poland",
-        "cost": 75,
-        "maintenance": 0,
+        "cost": 100,
         "requiredNearbyImprovedResources": ["Horses","Sheep","Cattle"],
         "hurryCostModifier": 25,
-        "uniques": ["[+1 Production, +1 Gold] from [Pasture] tiles [in this city]",
+        "uniques": ["[+1 Gold] from [Maize] tiles [in this city]",
             "New [Mounted] units start with [15] Experience [in this city]","[+15]% Production when constructing [Mounted] units [in this city]","[+1 Production, +1 Gold] from [Cattle] tiles [in this city]",
         	"[+1 Production, +1 Gold] from [Horses] tiles [in this city]",
         	"[+1 Production, +1 Gold] from [Sheep] tiles [in this city]",],
@@ -638,8 +637,8 @@
         "maintenance": 1,
         "requiredNearbyImprovedResources": ["Horses","Sheep","Cattle"],
         "hurryCostModifier": 25,
-        "uniques": ["Provides [2] [Horses]","[+1 Faith] from [Horses] tiles [in this city]","[+15]% Production when constructing [Mounted] units [in this city]","[+1 Production] from [Cattle] tiles [in this city]",
-        	"[+1 Production] from [Horses] tiles [in this city]",
+        "uniques": ["Provides [2] [Horses]","[+15]% Production when constructing [Mounted] units [in this city]","[+1 Production] from [Cattle] tiles [in this city]",
+        	"[+1 Production, +1 Faith] from [Horses] tiles [in this city]",
         	"[+1 Production] from [Sheep] tiles [in this city]",]
         "requiredTech": "Horseback Riding"
     },
@@ -704,18 +703,17 @@
         "replaces": "Colosseum",
 		"uniqueTo": "Kongo",
 		"gold": 5,
-        "production": 3,
+        "production": 4,
         "hurryCostModifier": 25,
-		"uniques": ["[+2 Production] <after discovering [Industrialization]>"],
+		"uniques": ["[+3 Production, +2 Gold] <after discovering [Industrialization]>"],
         "requiredTech": "Construction"
     },
     {
         "name": "Terracotta Army", //adjusted
         "culture": 1,
         "isWonder": true,
-        "greatPersonPoints": {"Great Artist": 1},
         "requiredTech": "Construction",
-        "uniques": ["Free [Warrior] appears","Free [Archer] appears","Free [Composite Bowman] appears","Free [Spearman] appears"],
+        "uniques": ["Free [Warrior] appears","Free [Archer] appears","Free [Horseman] appears","Free [Spearman] appears"],
         "quote": "'Regard your soldiers as your children, and they will follow you into the deepest valleys; look on them as your own beloved sons, and they will stand by you even unto death.'  - Sun Tzu"
     },
     {
@@ -727,21 +725,11 @@
         "requiredTech": "Philosophy"
     },
     {
-        "name": "Amphitheater",
-        "culture": 2,
-        "specialistSlots": {"Artist": 1},
-        "maintenance": 2,
-        "hurryCostModifier": 25,
-        "requiredBuilding": "Monument",
-	"uniques": ["Destroyed when the city is captured"],
-        "requiredTech": "Drama and Poetry"
-    },
-    {
 	"name": "Stave Church",
         "replaces": "Temple",
 	"uniqueTo": "Norway",
-        "faith": 1,
-        "specialistSlots": {"Artist": 1},
+        "faith": 2,
+        "cost": 75,
         "hurryCostModifier": 25,
         "requiredBuilding": "Shrine",
         "uniques": ["[+1 Faith] from [Water resource] tiles [in this city]"],
@@ -766,57 +754,76 @@
         "maintenance": 1,
         "hurryCostModifier": 25,
         "requiredBuilding": "Shrine",
-        "uniques": ["[+5]% [Science] [in this city]"],
+        "uniques": ["[+10]% [Science] [in this city]"],
         "requiredTech": "Philosophy"
     },
-	    {
-        "name": "Odeon",
-        "replaces": "Amphitheater",
-        "uniqueTo": "Greece",
-        "culture": 4,
-        "gold": 1,
-        "specialistSlots": {"Artist": 1},
-        "hurryCostModifier": 25,
-        "requiredBuilding": "Monument",
-	"uniques": ["Destroyed when the city is captured"],
-        "requiredTech": "Philosophy"
-    },
-		    {
-        "name": "Hippodrome",
-        "replaces": "Amphitheater",
-        "uniqueTo": "Byzantium",
-        "culture": 2,
-	"faith": 2,
-	"happiness": 1,
-        "maintenance": 1,
-        "specialistSlots": {"Artist": 1},
-        "hurryCostModifier": 25,
-        "requiredBuilding": "Monument",
-	"uniques": ["Destroyed when the city is captured"],
-        "requiredTech": "Philosophy"
-    },
-		    {
-        "name": "Yeshiva",
-        "replaces": "Temple",
-        "uniqueTo": "Israel",
-        "faith": 2,
-	"cost": 120,
-        "food": 1,
-	"production": 1,
-	"maintenance": 2,
-        "specialistSlots": {"Artist": 1},
-        "hurryCostModifier": 25,
-        "requiredBuilding": "Shrine",
-        "requiredTech": "Philosophy"
+		{
+      "name": "Yeshiva",
+      "replaces": "Temple",
+      "uniqueTo": "Israel",
+      "faith": 2,
+	    "cost": 120,
+      "food": 1,
+	    "production": 1,
+	    "maintenance": 2,
+      "hurryCostModifier": 25,
+      "requiredBuilding": "Shrine",
+      "requiredTech": "Philosophy"
     },
     {
         "name": "Mud Pyramid Mosque",
         "replaces": "Temple",
         "uniqueTo": "Songhai",
-        "faith": 4,
-        "hurryCostModifier": 15,
+        "faith": 2,
+        "culture": 2,
+        "hurryCostModifier": 25,
         "requiredBuilding": "Shrine",
         "requiredTech": "Philosophy"
+    },
+    {
+        "name": "Amphitheater",
+        "culture": 4,
+        "specialistSlots": {"Artist": 1},
+        "maintenance": 2,
+        "hurryCostModifier": 25,
+        "requiredBuilding": "Monument",
+	"uniques": ["Destroyed when the city is captured"],
+        "requiredTech": "Drama and Poetry"
+    },
+	    {
+        "name": "Odeon",
+        "replaces": "Amphitheater",
+        "uniqueTo": "Greece",
+        "culture": 6,
+        "gold": 1,
+        "specialistSlots": {"Artist": 2},
+        "hurryCostModifier": 25,
+        "requiredBuilding": "Monument",
+	"uniques": ["Destroyed when the city is captured"],
+        "requiredTech": "Drama and Poetry"
+    },
+		    {
+        "name": "Hippodrome",
+        "replaces": "Amphitheater",
+        "uniqueTo": "Byzantium",
+        "culture": 4,
+	      "faith": 2,
+	      "happiness": 1,
+        "maintenance": 2,
+        "specialistSlots": {"Artist": 1},
+        "hurryCostModifier": 25,
+        "requiredBuilding": "Monument",
+	      "uniques": ["Destroyed when the city is captured"],
+        "requiredTech": "Drama and Poetry"
+    },
+    {
+        "name": "Writer Guild", 
+        "cost": 150,
+        "maintenance": 1
+        "greatPersonPoints": {"Great Artist": 1},
+        "specialistSlots": {"Artist": 2},
+        "isNationalWonder": true,
+        "requiredTech": "Drama and Poetry"
     },
     {
         "name": "The Oracle",
@@ -838,7 +845,7 @@
     {
         "name": "National Epic",
         "cost": 125,
-        "culture": 1,
+        "culture": 3,
         "uniques": ["[+25]% Great Person generation [in this city]","Cost increases by [30] per owned city",
             "Requires a [Monument] in all cities"],
         "isNationalWonder": true,
@@ -851,27 +858,27 @@
         "cost": 125,
         "culture": 4,
 		"faith": 4,
-        "uniques": ["[+25]% Great Person generation [in this city]","[+2 Food, +1 Gold, +1 Production, +1 Culture] from every [Shrine]","Cost increases by [30] per owned city",
+        "uniques": ["[+25]% Great Person generation [in this city]","[+2 Food, +1 Gold, +1 Production, +1 Faith] from every [Shrine]","Cost increases by [30] per owned city",
             "Requires a [Shrine] in all cities"],
         "isNationalWonder": true,
         "requiredTech": "Drama and Poetry"
     },
     {
         "name": "Market",
-        "gold": 2,
+        "gold": 1,
         "specialistSlots": {"Merchant": 1},
         "hurryCostModifier": 25,
-        "uniques": ["[+25]% [Gold] [in this city]"],
+        "uniques": ["[+25]% [Gold] [in this city]","[+1 Gold] from every [Land Trade Route (Gold)]","[+1 Gold] from every [Sea Trade Route (Gold)]"],
         "requiredTech": "Currency"
     },
 	    {
         "name": "Knyaz Court",
         "replaces": "Market",
 		"uniqueTo": "Ukraine",
-		"gold": 3,
+		"gold": 2,
         "specialistSlots": {"Merchant": 1},
         "hurryCostModifier": 25,
-        "uniques": ["[+30]% [Gold] [in this city]"],
+        "uniques": ["Provides a sum of gold each time you spend a Great Person","[+25]% [Gold] [in this city]","[+1 Gold] from every [Land Trade Route (Gold)]","[+1 Gold] from every [Sea Trade Route (Gold)]"],
         "requiredTech": "Currency"
     },
     {
@@ -883,28 +890,26 @@
         "hurryCostModifier": 25,
         "uniques": ["Provides 1 extra copy of each improved luxury resource near this City",
             "[+2 Gold] from [Oil] tiles [in this city]","[+2 Gold] from [Oasis] tiles [in this city]",
-            "[+25]% [Gold] [in this city]"],
+            "[+25]% [Gold] [in this city]","[+1 Gold] from every [Land Trade Route (Gold)]","[+1 Gold] from every [Sea Trade Route (Gold)]"],
         "requiredTech": "Currency"
     },
     {
         "name": "Mint",
-        "maintenance": 0,
-	    "gold": 2,
-        "requiredNearbyImprovedResources": ["Gold Ore","Silver","Copper","Amber","Lapis Lazuli","Jade"],
+        "gold":2,
+        "requiredNearbyImprovedResources": ["Gold Ore","Silver","Copper"],
         "hurryCostModifier": 25,
-	    "uniques": ["[+2 Gold] from [Lapis Lazuli] tiles [in this city]","[+2 Gold] from [Amber] tiles [in this city]","[+2 Gold] from [Jade] tiles [in this city]","[+2 Gold] from [Gold Ore] tiles [in this city]","[+2 Gold] from [Silver] tiles [in this city]","[+2 Gold] from [Copper] tiles [in this city]"]
+	    "uniques": ["[+2 Gold] from [Gold Ore] tiles [in this city]","[+2 Gold] from [Silver] tiles [in this city]","[+2 Gold] from [Copper] tiles [in this city]"]
         "requiredTech": "Currency"
     },  
 	    {
 		"name": "Silversmith",
 		"uniqueTo": "Celts",
         "replaces": "Mint",
-        "maintenance": 0,
         "production": 2,
 	"gold": 1,
 	"cost": 75,
         "hurryCostModifier": 25,
-		"uniques": ["[+2 Gold] from [Lapis Lazuli] tiles [in this city]","[+2 Gold] from [Amber] tiles [in this city]","[+2 Gold] from [Jade] tiles [in this city]","[+2 Gold] from [Gold Ore] tiles [in this city]","[+2 Gold] from [Silver] tiles [in this city]","[+2 Gold] from [Copper] tiles [in this city]"]
+		"uniques": ["[+2 Gold] from [Gold Ore] tiles [in this city]","[+2 Gold] from [Silver] tiles [in this city]","[+2 Gold] from [Copper] tiles [in this city]"]
         "requiredTech": "Currency"
     }, 
     {
@@ -926,7 +931,7 @@
     },
     {
         "name": "Great Wall",
-        "culture": 3,
+        "culture": 1,
         "greatPersonPoints": {"Great Engineer": 1},
         "isWonder": true,
         "uniques": ["Gain a free [Walls] [in this city]","Gain a free [Watch Tower] [in all cities]"],
@@ -941,34 +946,35 @@
         "maintenance": 1,
         "requiredTech": "Drama and Poetry"
     },
-		    {
-		"name": "Painted Monastery"
-        "replaces": "Garden",
-		"uniqueTo": "Romania",
-        "cost": 120,
-		"greatPersonPoints": {"Great Artist":1 },
-		"faith": 2,
-        "uniques": ["[+25]% Great Person generation [in this city]"],
-        "hurryCostModifier": 25,
-        "maintenance": 1,
-        "requiredTech": "Drama and Poetry"
+		{
+		  "name": "Painted Monastery"
+      "replaces": "Garden",
+	  	"uniqueTo": "Romania",
+      "cost": 120,
+		  "greatPersonPoints": {"Great Artist":1 },
+  		"faith": 2,
+  		"production": 1,
+      "uniques": ["[+25]% Great Person generation [in this city]"],
+      "hurryCostModifier": 25,
+      "maintenance": 1,
+      "requiredTech": "Drama and Poetry"
     },
-		    {
-        "name": "Baray",
-		"replaces": "Garden",
-		"uniqueTo": "Khmer",
-        "cost": 120,
-        "uniques": ["[10]% Food is carried over after population increases [in this city]", "[+2 Food, +2 Faith] <after discovering [Drama and Poetry]>","[+25]% Great Person generation [in this city]", "Must be next to [Fresh water]"],
-        "hurryCostModifier": 25,
-        "maintenance": 1,
-        "requiredTech": "Drama and Poetry"
+		{
+      "name": "Baray",
+	  	"replaces": "Garden",
+  		"uniqueTo": "Khmer",
+      "cost": 120,
+      "uniques": ["[10]% Food is carried over after population increases [in this city]", "[+2 Food, +2 Faith] <after discovering [Drama and Poetry]>","[+25]% Great Person generation [in this city]"],
+      "hurryCostModifier": 25,
+      "maintenance": 1,
+      "requiredTech": "Drama and Poetry"
     },
     {
         "name": "Candi", 
         "replaces": "Garden",
         "uniqueTo": "Indonesia",
         "cost": 120,
-        "faith": 3,
+        "faith": 4,
         "uniques": ["[+25]% Great Person generation [in this city]"],
         "hurryCostModifier": 25,
         "maintenance": 1,
@@ -978,14 +984,6 @@
     // Medieval Era
 
     {
-        "name": "Monastery",
-        "maintenance": 0,
-        "requiredNearbyImprovedResources": ["Wine","Incense","Perfume"],
-        "hurryCostModifier": 25,
-        "requiredTech": "Theology"
-	"uniques": ["[+1 Faith, +1 Culture] from [Incense] tiles [in this city]","[+1 Faith, +1 Culture] from [Wine] tiles [in this city]","[+1 Culture, +1 Faith] from [Perfume] tiles [in this city]"]
-    },
-    {
         "name": "Grand Temple", 
 		"culture": 1,
         "cost": 125,
@@ -994,8 +992,19 @@
         "uniques": ["Cost increases by [30] per owned city","Requires a [Temple] in all cities","[+100]% Natural religion spread [in this city]","Can only be built [in holy cities]"],
         "requiredTech": "Theology"
     },
+    {
+        "name": "Grand Cathedral of Vilnius", 
+        "replaces": "Grand Temple",
+        "uniqueTo": "Lithuania",
+		    "culture": 1,
+        "cost": 95,
+        "faith": 8,
+        "isNationalWonder": true,
+        "uniques": ["Cost increases by [30] per owned city","Requires a [Temple] in all cities"],
+        "requiredTech": "Theology"
+    },
 	    {
-        "name": "Saint Peter’s Basilica", 
+        "name": "Saint Peter's Basilica", 
 		"replaces": "Grand Temple",
 		"uniqueTo": "Papal State",
 		"culture": 1,
@@ -1006,11 +1015,24 @@
         "requiredTech": "Theology"
     },
     {
+        "name": "Borobudur", 
+        "faith": 5,
+        "culture": 1,
+        "greatPersonPoints": {"Great Engineer": 1},
+        "cost": 300,
+        "isWonder": true,
+        "uniques": ["Gain a free [Garden] [in this city]","[3] free [Missionary] units appear","Can only be built [in holy cities]"],
+        "requiredTech": "Theology",
+        "quote": "'When you realize how perfect everything is, you will tilt your head back and laugh at the sky.'  - Gautama Buddha"
+    },
+    {
         "name": "Great Mosque of Djenne",
         "faith": 6,
-		"happiness": 3,
+        "happiness": 3,
+        "culture": 3,
+        "greatPersonPoints": {"Great Engineer": 1},
         "isWonder": true,
-        "uniques": ["Gain a free [Mosque] [in this city]","[Missionary] units built [in this city] can [Spread Religion] [1] extra times", "[Great Prophet] units built [in this city] can [Spread Religion] [1] extra times","Only available <after adopting [Piety]>"],
+        "uniques": ["[Missionary] units built [in this city] can [Spread Religion] [1] extra times", "[Great Prophet] units built [in this city] can [Spread Religion] [1] extra times","Only available <after adopting [Piety]>"],
         "requiredTech": "Philosophy",
         "quote": "With the magnificence of eternity before us, let time, with all its fluctuations, dwindle into its own littleness.  – Thomas Chalmers"
     },
@@ -1020,7 +1042,7 @@
 		"culture": 1,
         "greatPersonPoints": {"Great Artist": 1},
         "isWonder": true,
-        "uniques": ["Gain a free [Cathedral] [in this city]","Free [Great Prophet] appears"],
+        "uniques": ["Gain a free [Temple] [in this city]","Free [Great Prophet] appears"],
         "requiredTech": "Theology",
         "quote": "'For it soars to a height to match the sky, and as if surging up from among the other buildings it stands on high and looks down upon the remainder of the city, adorning it, because it is a part of it, but glorying in its own beauty'  - Procopius, De Aedificis"
     },
@@ -1047,13 +1069,33 @@
     {
         "name": "East India Company", 
         "cost": 125,
-        "gold": 4,
+        "gold": 2,
         "culture": 1,
         "isNationalWonder": true,
-        "uniques": ["Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]","[+1 Gold] from every [Land Trade Route (Food)]","[+1 Gold] from every [Land Trade Route (Production)]",
-            "[+2 Gold] from every [Land Trade Route (Gold)]","[+1 Gold] from every [Sea Trade Route (Food)]",
-            "[+1 Gold] from every [Sea Trade Route (Production)]","[+2 Gold] from every [Sea Trade Route (Gold)]",
+        "uniques": ["Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]",
+            "[+4 Gold] from every [Land Trade Route (Gold)]","[+4 Gold] from every [Sea Trade Route (Gold)]", "[+10]% [Gold] [in this city]",
             "Cost increases by [30] per owned city","Requires a [Market] in all cities"],
+        "requiredTech": "Guilds"
+    },
+    {
+        "name": "Grand Canal of Venice", 
+        "cost": 125,
+        "gold": 2,
+        "culture": 1,
+        "uniqueTo": "Venice",
+        "replaces": "East India Company"
+        "isNationalWonder": true,
+        "uniques": ["Provides [2] [Trade Route (Count)]","Provides [2] [Trade Route]",
+            "[+4 Gold] from every [Land Trade Route (Gold)]","[+4 Gold] from every [Sea Trade Route (Gold)]", "[+25]% [Gold] [in this city]"],
+        "requiredTech": "Curr"
+    },
+    {
+        "name": "Artist Guild", 
+        "cost": 150,
+        "maintenance": 1
+        "greatPersonPoints": {"Great Artist": 2},
+        "specialistSlots": {"Artist": 2},
+        "isNationalWonder": true,
         "requiredTech": "Guilds"
     },
     {
@@ -1062,13 +1104,14 @@
         "culture": 1,
 		"cost": 300,
         "isWonder": true,
-        "uniques": ["[+1 Culture] from every [Tundra]","[+1 Production] from every [Tundra]","Must be next to [Coast]"],
+        "uniques": ["[+1 Culture, +1 Production] from every [Tundra]","Must be next to [Tundra]"],
         "requiredTech": "Metal Casting",
         "quote": "'...who drinks the water I shall give him, says the Lord, will have a spring inside him welling up for eternal life. Let them bring me to your holy mountain in the place where you dwell. Across the desert and through the mountain to the Canyon of the Crescent Moon...'  - Indiana Jones"
     },
 	    {
         "name": "Machu Picchu",
         "gold": 5,
+        "faith": 2,
         "greatPersonPoints": {"Great Merchant": 1},
         "culture": 1,
         "isWonder": true,
@@ -1082,8 +1125,19 @@
         "production": 2, 
         "specialistSlots": {"Engineer": 1},
         "hurryCostModifier": 25,
-        "uniques": ["[+1 Production] from [Land Trade Route (Production)] tiles [in this city]", "[+1 Production] from [Hardwood] tiles [in this city]"
-            "[+2 Production] from [Sea Trade Route (Production)] tiles [in this city]","[+10]% [Production] [in this city]"],
+        "uniques": ["[+10]% [Production] [in this city]"],
+        "requiredTech": "Metal Casting"
+    },
+    {
+        "name": "Longhouse",
+        "replaces": "Workshop",
+        "uniqueTo": "Iroquois",
+        "cost": 75,
+        "maintenance": 2,
+        "production": 2,
+        "specialistSlots": {"Engineer": 1},
+        "hurryCostModifier": 25,
+        "uniques": ["[+10]% [Production] [in this city]","[+1 Production] from [Forest] tiles [in this city]","[+1 Production] from [Jungle] tiles [in this city]"],
         "requiredTech": "Metal Casting"
     },
 	    {
@@ -1094,8 +1148,7 @@
         "production": 1,
         "specialistSlots": {"Engineer": 1},
         "hurryCostModifier": 25,
-        "uniques": ["[+2 Production] from [Coral] tiles [in this city]","[+1 Production] from [Hardwood] tiles [in this city]","[+1 Culture] from [Crab] tiles [in this city]","[+1 Production] from [Hardwood] tiles [in this city]","[+1 Culture] from [Pearls] tiles [in this city]","[+2 Gold] from [Whales] tiles [in this city]","[+1 Food] from [Fish] tiles [in this city]","[+1 Production] from [Land Trade Route (Production)] tiles [in this city]",
-            "[+2 Production] from [Sea Trade Route (Production)] tiles [in this city]","[+10]% [Production] [in this city]"],
+        "uniques": ["[+2 Production] from [Coral] tiles [in this city]","[+1 Culture] from [Crab] tiles [in this city]","[+1 Culture] from [Pearls] tiles [in this city]","[+2 Gold] from [Whales] tiles [in this city]","[+1 Culture] from [Fish] tiles [in this city]","[+10]% [Production] [in this city]"],
         "requiredTech": "Metal Casting"
     },
 	    {
@@ -1126,47 +1179,41 @@
 		"gold": 2,
         "hurryCostModifier": 25,
 			    	"uniques": ["[+2 Gold] from [Sugar] tiles [in this city]","[+2 Gold] from [Coffee] tiles [in this city]","[+2 Gold] from [Wine] tiles [in this city]","[+2 Gold] from [Salt] tiles [in this city]","[+2 Gold] from [Tea] tiles [in this city]"],
-        "requiredTech": "Education"
+        "requiredTech": "Guilds"
     }, 
-    {
-        "name": "Longhouse",
-        "replaces": "Workshop",
-        "uniqueTo": "Iroquois",
-        "cost": 75,
-        "maintenance": 2,
-        "production": 2,
-        "specialistSlots": {"Engineer": 1},
-        "hurryCostModifier": 25,
-        "uniques": ["[+10]% [Production] [in this city]","[+1 Production] from [Forest] tiles [in this city]","[+1 Production] from [Jungle] tiles [in this city]","[+1 Production] from [Land Trade Route (Production)] tiles [in this city]",
-            "[+2 Production] from [Sea Trade Route (Production)] tiles [in this city]"],
-        "requiredTech": "Metal Casting"
-    },
     {
         "name": "Forge",
         "maintenance": 1,
         "hurryCostModifier": 25,
         "requiredNearbyImprovedResources": ["Iron","Coal","Aluminum","Uranium"],
         "requiredTech": "Metal Casting",
-        "uniques": ["[+15]% Production when constructing [Land] units [in this city]",
-            "[+15]% Production when constructing [Spaceship part] units [in this city]","[+1 Production] from [Iron] tiles [in this city]"]
+        "uniques": ["[+15]% Production when constructing [Land] units [in this city]","[+1 Production] from [Iron] tiles [in this city]","[+1 Production] from [Coal] tiles [in this city]", "[+1 Production] from [Aluminum] tiles [in this city]","[+1 Production] from [Uranium] tiles [in this city]"]
     },
 	    {
-		"name": "Blast Furnace",
+	      "name": "Blast Furnace",
         "replaces": "Forge",
-		"uniqueTo": "Nubia",
-        "maintenance": 1,
+		    "uniqueTo": "Nubia",
+		    "culture": 2,
         "hurryCostModifier": 25,
         "requiredTech": "Metal Casting",
-        "uniques": ["All newly-trained [relevant] units [in this city] receive the [Accuracy I] promotion","[+2 Culture, +1 Production] from [Iron] tiles [in this city]","[+1 Production] from [Coal] tiles [in this city]","[+1 Production] from [Aluminum] tiles [in this city]","[+1 Production] from [Uranium] tiles [in this city]","[+15]% Production when constructing [Land] units [in this city]",
-            "[+15]% Production when constructing [Spaceship part] units [in this city]"]
+        "uniques": ["All newly-trained [Ranged] units [in this city] receive the [Accuracy I] promotion","All newly-trained [Scout] units [in this city] receive the [Accuracy I] promotion","All newly-trained [Siege] units [in this city] receive the [Accuracy I] promotion","[+1 Production, +2 Culture] from [Iron] tiles [in this city]","[+1 Production] from [Coal] tiles [in this city]", "[+1 Production] from [Aluminum] tiles [in this city]","[+1 Production] from [Uranium] tiles [in this city]","[+15]% Production when constructing [Land] units [in this city]"]
     },
     {
         "name": "Harbor",
         "maintenance": 2,
         "hurryCostModifier": 25,
-        "uniques": ["[+1 Gold] from [Sea Trade Route (Food)] tiles [in this city]",
-            "[+1 Gold] from [Sea Trade Route (Production)] tiles [in this city]","[+1 Gold] from [Sea Trade Route (Gold)] tiles [in this city]",
+        "uniques": ["[+2 Gold] from [Sea Trade Route (Gold)] tiles [in this city]",
             "Connects trade routes over water","Must be next to [Coast]"],
+        "requiredTech": "Compass"
+    },
+    {
+        "name": "Feitoria",
+        "uniqueTo": "Portugal",
+        "replaces":"Harbor"
+        "hurryCostModifier": 25,
+        "cost": 100,
+        "uniques": ["[+2 Gold] from [Sea Trade Route (Gold)] tiles [in this city]","[+1 Gold] from [Water resource] tiles [in this city]",
+            "Connects trade routes over water","Must be next to [Coast]","New [Water] units start with [15] Experience [in this city]"],
         "requiredTech": "Compass"
     },
 	    {
@@ -1176,20 +1223,17 @@
         "maintenance": 2,
 		"cityStrength": 5,
         "hurryCostModifier": 25,
-        "uniques": ["[+1 Gold] from [Sea Trade Route (Food)] tiles [in this city]",
-            "[+1 Gold] from [Sea Trade Route (Production)] tiles [in this city]","[+1 Gold] from [Sea Trade Route (Gold)] tiles [in this city]","[+2 Production] from [Sea Trade Route (Food)] tiles [in this city]",
-            "[+2 Production] from [Sea Trade Route (Production)] tiles [in this city]","[+2 Production] from [Sea Trade Route (Gold)] tiles [in this city]",
+        "uniques": ["[+2 Production] from [Sea Trade Route (Food)] tiles [in this city]", "[+2 Production] from [Sea Trade Route (Production)] tiles [in this city]", "[+2 Gold, +2 Production] from [Sea Trade Route (Gold)] tiles [in this city]",
             "Connects trade routes over water","Must be next to [Coast]"],
         "requiredTech": "Compass"
     },
 	{
-        "name": "Trade Harbour",
+        "name": "Trade Harbor",
 		"replaces": "Harbor",
 		"uniqueTo": "Phoenicia",
         "maintenance": 2,
         "hurryCostModifier": 25,
-        "uniques": ["[+1 Production] from [Water resource] tiles [in this city]","[+15]% Production when constructing [Water] units [in this city]","[+1 Gold] from [Sea Trade Route (Food)] tiles [in this city]",
-            "[+1 Gold] from [Sea Trade Route (Production)] tiles [in this city]","[+1 Gold] from [Sea Trade Route (Gold)] tiles [in this city]",
+        "uniques": ["[+15]% Production when constructing [Water] units [in this city]","[+2 Gold] from [Sea Trade Route (Gold)] tiles [in this city]","[+1 Production] from [Water resource] tiles [in this city]",
             "Connects trade routes over water","Must be next to [Coast]"],
         "requiredTech": "Compass"
     },
@@ -1209,7 +1253,6 @@
         "culture": 3,
         "maintenance": 2,
         "hurryCostModifier": 15,
-        "percentStatBonus": {"science": 33},
         "specialistSlots": {"Scientist": 2},
         "requiredBuilding": "Library",
         "uniques": ["[+2 Science] from [Jungle] tiles [in this city]","[+33]% [Science] [in this city]"],
@@ -1222,7 +1265,6 @@
         "faith": 2,
         "maintenance": 2,
         "hurryCostModifier": 15,
-        "percentStatBonus": {"science": 33},
         "specialistSlots": {"Scientist": 2},
         "requiredBuilding": "Library",
         "uniques": ["[+2 Science] from [Jungle] tiles [in this city]","[+2 Science] from [Oasis] tiles [in this city]","[+1 Science] from [Flood plains] tiles [in this city]","[+33]% [Science] [in this city]"],
@@ -1232,7 +1274,7 @@
         "name": "Oxford University",
         "cost": 125,
         "science": 3,
-        "culture": 1,
+        "culture": 5,
         "isNationalWonder": true,
         "uniques": ["Free Technology","Cost increases by [30] per owned city",
             "Requires a [University] in all cities"],
@@ -1268,7 +1310,7 @@
         "culture": 4,
 		"happiness": 2,
         "hurryCostModifier": 25,
-		"uniques": ["Destroyed when the city is captured","[+1 Gold] <after discovering [Flight]>"],
+		"uniques": ["Destroyed when the city is captured","[+1 Culture] <after discovering [Flight]>"],
         "requiredTech": "Chivalry"
     },
     {
@@ -1277,7 +1319,7 @@
 		"science": 5,
         "greatPersonPoints": {"Great Scientist": 1},
         "isWonder": true,
-		"uniques": ["Gain a free [Wat] [in this city]"],
+		"uniques": ["Gain a free [University] [in this city]"],
         "requiredTech": "Education",
         "quote": "'The temple is like no other building in the world. It has towers and decoration and all the refinements which the human genius can conceive of.'  - Antonio da Magdalena"
     },
@@ -1314,6 +1356,7 @@
     {
         "name": "Notre Dame",
         "faith": 4,
+        "culture": 1,
         "happiness": 10,
         "greatPersonPoints": {"Great Artist": 1},
         "isWonder": true,
@@ -1354,9 +1397,9 @@
 		"uniqueTo": "Armenia",
         "maintenance": 0,
 		"science": 4,
-		"culture": 1,
+		"culture": 4,
         "hurryCostModifier": 15,
-        "uniques": ["[+4 Science] from [Mountain] tiles [in this city]","[+3 Culture, +4 Science] from [Mountain] tiles [in this city]"],
+        "uniques": ["[+4 Science, +2 Culture] from [Mountain] tiles [in this city]"],
         "requiredTech": "Astronomy"
     },
     {
@@ -1387,7 +1430,7 @@
         "name": "Staatsmuseum", 
         "replaces": "Opera House",
         "uniqueTo": "Boers",
-        "culture": 6,
+        "culture": 4,
         "specialistSlots": {"Artist": 1},
         "cost": 200,
         "hurryCostModifier": 25,
@@ -1397,10 +1440,18 @@
         "requiredTech": "Acoustics"
     },
     {
+        "name": "Musician Guild", 
+        "cost": 200,
+        "maintenance": 1
+        "greatPersonPoints": {"Great Artist": 3},
+        "specialistSlots": {"Artist": 2},
+        "isNationalWonder": true,
+        "requiredTech": "Acoustics"
+    },
+    {
         "name": "Sistine Chapel",
-        "culture": 1,
+        "culture": 5,
         "isWonder": true,
-        "greatPersonPoints": {"Great Artist": 2},
         "uniques": ["[+25]% [Culture] [in all cities]"],
         "requiredTech": "Acoustics",
         "quote": "'I live and love in God's peculiar light.' - Michelangelo Buonarroti"
@@ -1415,27 +1466,17 @@
         "requiredTech": "Banking"
     },
     {
-	"name": "Canton Factory",
-        "replaces": "Bank",
-	"uniqueTo": "Manchuria",
-        "gold": 4,
-	"cost": 125,
-        "specialistSlots": {"Merchant": 2},
-        "hurryCostModifier": 15,
-        "requiredBuilding": "Market",
-        "uniques": ["[+35]% [Gold] [in this city]"],
-        "requiredTech": "Banking"
+      "name": "Canton Factory",
+      "replaces": "Bank",
+    	"uniqueTo": "Manchuria",
+      "gold": 4,
+    	"cost": 100,
+      "specialistSlots": {"Merchant": 2},
+      "hurryCostModifier": 15,
+      "requiredBuilding": "Market",
+      "uniques": ["[+35]% [Gold] [in this city]"],
+      "requiredTech": "Banking"
     },
-		    {
-        "name": "Grocer",
-        "maintenance": 0,
-        "requiredNearbyImprovedResources": ["Citrus","Olives","Truffles","Cocoa","Spices"],
-		"cost": 100,
-		"food": 1,
-        "hurryCostModifier": 25,
-	"uniques": ["[+1 Food] from [Truffles] tiles [in this city]","[+1 Food] from [Spices] tiles [in this city]","[+1 Food] from [Cocoa] tiles [in this city]","[+1 Food] from [Olives] tiles [in this city]","[+1 Food] from [Citrus] tiles [in this city]"],
-        "requiredTech": "Banking"
-    }, 
     {
         "name": "Satrap's Court",
         "replaces": "Bank",
@@ -1455,7 +1496,7 @@
         "gold": 2,
         "specialistSlots": {"Merchant": 1},
         "hurryCostModifier": 15,
-	"cost": 250,
+	      "cost": 150,
         "requiredBuilding": "Market",
         "uniques": ["[+30]% [Gold] [in this city]","[+5]% [Production] [in this city]"],
         "requiredTech": "Machinery"
@@ -1472,6 +1513,16 @@
             "[+25]% [Gold] [in this city]"],
         "requiredTech": "Banking"
     },
+		    {
+        "name": "Grocer",
+        "maintenance": 0,
+        "requiredNearbyImprovedResources": ["Citrus","Olives","Truffles","Cocoa","Spices"],
+		"cost": 100,
+		"food": 1,
+        "hurryCostModifier": 25,
+	"uniques": ["[+1 Food] from [Truffles] tiles [in this city]","[+1 Food] from [Spices] tiles [in this city]","[+1 Food] from [Cocoa] tiles [in this city]","[+1 Food] from [Olives] tiles [in this city]","[+1 Food] from [Citrus] tiles [in this city]"],
+        "requiredTech": "Banking"
+    }, 
 	    {
         "name": "Textile Mill",
         "maintenance": 0,
@@ -1486,7 +1537,6 @@
         "name": "Forbidden Palace",
         "culture": 1,
         "isWonder": true,
-        "greatPersonPoints": {"Great Artist": 1},
         "uniques": ["[-10]% Unhappiness from [Population] [in all cities]","Only available <after adopting [Patronage]>"],
         "requiredTech": "Banking",
         "quote": "'Most of us can, as we choose, make of this world either a palace or a prison' - John Lubbock"
@@ -1496,31 +1546,31 @@
         "happiness": 2,
         "hurryCostModifier": 10,
         "maintenance": 2,
-	"cost": 200,
+	"cost": 180,
         "requiredBuilding": "Colosseum",
         "requiredTech": "Printing Press"
     },
     {
-        "name": "Irish Pub",
-	"replaces": "Zoo",
-	"uniqueTo": "Ireland",
-        "happiness": 3,
-	"food": 3,
-        "hurryCostModifier": 10,
-	"cost": 225,
-        "requiredBuilding": "Colosseum",
-        "uniques": ["[+1 Production] from [Coffee] tiles [in this city]","[+1 Production] from [Wine] tiles [in this city]","[+1 Production] from [Tea] tiles [in this city]"],
-        "requiredTech": "Printing Press"
+      "name": "Irish Pub",
+	    "replaces": "Zoo",
+	    "uniqueTo": "Ireland",
+      "happiness": 2,
+	    "food": 3,
+      "hurryCostModifier": 10,
+	    "cost": 180,
+      "requiredBuilding": "Colosseum",
+      "uniques": ["[+1 Production] from [Coffee] tiles [in this city]","[+1 Production] from [Wine] tiles [in this city]","[+1 Production] from [Tea] tiles [in this city]"],
+      "requiredTech": "Printing Press"
     },
 	    {
         "name": "Stade",
-		"replaces": "Zoo",
-		"uniqueTo": "Belgium",
+		    "replaces": "Zoo",
+		    "uniqueTo": "Belgium",
         "happiness": 3,
-		"culture": 1,
-		"cost": 150,
-        "hurryCostModifier": 10,
+		    "culture": 1,
         "gold": 1,
+		    "cost": 150,
+        "hurryCostModifier": 10,
         "requiredTech": "Printing Press"
     },
     {
@@ -1543,7 +1593,7 @@
     },
     {
         "name": "Museum",
-        "culture": 5,
+        "culture": 6,
         "specialistSlots": {"Artist": 2},
         "maintenance": 3,
         "hurryCostModifier": 0,
@@ -1555,19 +1605,19 @@
         "name": "Basilica",
 	"replaces": "Museum",
 	"uniqueTo": "Italy",
-        "culture": 5,
+        "culture": 6,
         "specialistSlots": {"Artist": 2},
 	"greatPersonPoints": {"Great Artist":2},
         "maintenance": 3,
         "hurryCostModifier": 0,
         "requiredBuilding": "Amphitheater",
-	"uniques": ["Destroyed when the city is captured","[+10]% [Culture] [in this city]"],
+	"uniques": ["Destroyed when the city is captured","[+10]% [Culture] [in this city]","[+20]% Great Person generation [in this city]"],
         "requiredTech": "Industrialization"
     },
     {
         "name": "Hermitage",
         "cost": 125,
-        "culture": 5,
+        "culture": 11,
         "isNationalWonder": true,
         "uniques": ["[+50]% [Culture] [in this city]","Cost increases by [30] per owned city",
             "Requires a [Opera House] in all cities"],
@@ -1589,10 +1639,9 @@
     }, 
     {
         "name": "The Louvre",
-        "culture": 1,
-        "happiness": 4,
+        "culture": 10,
         "isWonder": true, 
-        "uniques": ["[2] free [Great Artist] units appear","Only available <after adopting [Exploration]>"],
+        "uniques": ["[1] free [Great Artist] units appear","Only available <after adopting [Exploration]>"],
         "requiredTech": "Archaeology",
         "quote": "'Every genuine work of art has as much reason for being as the earth and the sun'  - Ralph Waldo Emerson"
     },
@@ -1607,8 +1656,7 @@
     },
     {
         "name": "Uffizi", 
-        "culture": 2,
-        "specialistSlots": {"Artist": 3},
+        "culture": 8,
         "isWonder": true,
         "uniques": ["Free [Great Artist] appears","Only available <after adopting [Aesthetics]>"],
         "requiredTech": "Architecture",
@@ -1629,7 +1677,7 @@
         "culture": 1,
         "greatPersonPoints": {"Great Scientist": 2},
         "isWonder": true,
-        "uniques": ["Free [Great Scientist] appears","Science gained from research agreements [+50]%","Only available <after adopting [Rationalism]>"],
+        "uniques": ["[+3 Science, +3 Culture] from [Luxury resource] tiles [in this city]", ,"Only available <after adopting [Rationalism]>"],
         "requiredTech": "Architecture",
         "quote": "'Things always seem fairer when we look back at them, and it is out of that inaccessible tower of the past that Longing leans and beckons.'  - James Russell Lowell"
     }, 
@@ -1649,7 +1697,6 @@
         "production": 2,
         "specialistSlots": {"Engineer": 1},
         "hurryCostModifier": 25,
-        "maintenance": 2,
         "uniques": ["[+10]% Production when constructing [All] buildings [in this city]","[+1 Gold] from [Bonus resource] tiles [in this city]","[+1 Food] from [Strategic resource] tiles [in this city]","[+1 Production] from [Luxury resource] tiles [in this city]"],
         "requiredTech": "Economics"
     },
@@ -1662,8 +1709,8 @@
         "specialistSlots": {"Engineer": 1},
         "hurryCostModifier": 25,
         "maintenance": 2,
-        "uniques": ["[+5]% [Production] [in this city]","[+25]% Great Person generation [in this city]"],
-        "requiredTech": "Economics"     
+        "uniques": ["[+10]% Production when constructing [All] buildings [in this city]","[+5]% [Production] [in this city]","[+25]% Great Person generation [in this city]"],
+        "requiredTech": "Printing Press"     
     },
 	
     {
@@ -1681,7 +1728,7 @@
         "name": "Red Fort", 
         "culture": 8,
 		"happiness": 4,
-        "cityHealth": 12,
+        "cityStrength": 12,
         "isWonder": true,
         "greatPersonPoints": {"Great Scientist": 1},    
         "uniques": ["[+25]% City Strength from defensive buildings"],
@@ -1701,19 +1748,19 @@
         "uniques": ["[+1 Science] per [2] population [in this city]"],
         "requiredTech": "Scientific Theory"
     },
-	    {
-		"name": "Halkevleri"
-        "replaces": "Public School",
-		"uniqueTo": "Turkey",
-        "science": 3,
-		"culture": 3,
-		"cost": 288,
-        "specialistSlots": {"Scientist": 1},
-        "maintenance": 3,
-        "hurryCostModifier": 0,
-        "requiredBuilding": "University",
-        "uniques": ["[+1 Science] per [2] population [in this city]"],
-        "requiredTech": "Scientific Theory"
+    {
+      "name": "Halkevleri"
+      "replaces": "Public School",
+		  "uniqueTo": "Turkey",
+      "science": 3,
+		  "culture": 3,
+		  "cost": 240,
+      "specialistSlots": {"Scientist": 1},
+      "maintenance": 3,
+      "hurryCostModifier": 0,
+      "requiredBuilding": "University",
+      "uniques": ["[+1 Science] per [2] population [in this city]"],
+      "requiredTech": "Scientific Theory"
     },
     {
         "name": "Factory",
@@ -1759,7 +1806,7 @@
     },
     {
         "name": "Brandenburg Gate",
-        "culture": 3,
+        "culture": 1,
         "greatPersonPoints": {"Great Scientist": 2},
         "isWonder": true,
         "uniques": ["New [Military] units start with [15] Experience [in this city]","Free [Great General] appears"],
@@ -1783,25 +1830,37 @@
         "uniques": ["[+25]% [Gold] [in this city]"],
         "requiredTech": "Electricity"
     },
-	    {
-		"name": "Tim Hortons",
-		"uniqueTo": "Canada",
-        "replaces": "Stock Exchange",
-        "gold": 3,
-		"happiness": 2,
-        "specialistSlots": {"Merchant": 2},
-        "hurryCostModifier": 15,
-        "requiredBuilding": "Bank",
-        "uniques": ["[+25]% [Gold] [in this city]","[+1 Gold] from [River] tiles [in this city]"],
-        "requiredTech": "Electricity"
+    {
+      "name": "Tim Hortons",
+      "uniqueTo": "Canada",
+      "replaces": "Stock Exchange",
+      "gold": 3,
+	  	"happiness": 2,
+      "specialistSlots": {"Merchant": 2},
+      "cost": 300
+      "hurryCostModifier": 15,
+      "requiredBuilding": "Bank",
+      "uniques": ["[+25]% [Gold] [in this city]","[+1 Gold] from [River] tiles [in this city]"],
+      "requiredTech": "Electricity"
     },
 		    {
         "name": "Oil Refinery",
         "maintenance": 0,
         "requiredNearbyImprovedResources": ["Oil"],
-        "resourceBonusStats": {"production": 3, "gold": 3},
 		"cost": 200,
         "hurryCostModifier": 25,
+		"uniques": ["[+3 Production, +3 Gold] from [Oil] tiles [in this city]"],
+        "requiredTech": "Biology"
+    },
+		    {
+        "name": "BMPC Plant",
+        "maintenance": 0,
+        "replaces": "Oil Refinery"
+		    "cost": 200,
+		    "gold": 3,
+		    "production": 5,
+        "hurryCostModifier": 25,
+        "uniqueTo": "Brunei",
 		"uniques": ["[+3 Production, +3 Gold] from [Oil] tiles [in this city]"],
         "requiredTech": "Biology"
     }, 
@@ -1820,7 +1879,6 @@
         "name": "Prora", 
         "culture": 1,
         "happiness": 2,
-        "greatPersonPoints": {"Great Merchant": 2},
         "isWonder": true,
         "uniques": ["[+1 Happiness] per [2] additional social policies adopted","Free Social Policy","Only available <after adopting [Autocracy]>"],
         "requiredTech": "Flight",
@@ -1828,7 +1886,7 @@
     },
     {
         "name": "Broadcast Tower",
-        "culture": 3,
+        "culture": 4,
         "requiredBuilding": "Opera House",
         "uniques": ["Destroyed when the city is captured","[+10]% [Culture] [in this city]"],
         "maintenance": 3,
@@ -1838,7 +1896,6 @@
         "name": "Eiffel Tower", //adjusted
         "culture": 1,
         "happiness": 5,
-        "greatPersonPoints": {"Great Merchant": 2},
         "uniques": ["Gain a free [Broadcast Tower] [in this city]","[+100]% [Culture] [in this city]"],
         "isWonder": true,
         "requiredTech": "Radio",
@@ -1847,9 +1904,8 @@
     {
         "name": "Military Base", 
         "cost": 500,
-        "cityStrength": 9,
+        "cityStrength": 12,
         "cityHealth": 25,
-        "maintenance": 0,
         "hurryCostModifier": 25,
         "requiredBuilding": "Arsenal",
 	"uniques": ["Destroyed when the city is captured"],
@@ -1859,15 +1915,13 @@
         "name": "Statue of Liberty", //adjusted
         "culture": 1,
         "isWonder": true,
-        "greatPersonPoints": {"Great Engineer": 2},
         "uniques": ["[+1 Production] from every specialist [in all cities]","Free Social Policy","Only available <after adopting [Freedom]>"],
         "requiredTech": "Replaceable Parts",
         "quote": "'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!'  - Emma Lazarus"
     },
     {
         "name": "Research Lab",
-        "science": 4,       
-        "percentStatBonus": {"science": 50},
+        "science": 4,
         "specialistSlots": {"Scientist": 1},
         "maintenance": 3,
         "requiredBuilding": "Public School",
@@ -1876,7 +1930,7 @@
     },
     {
         "name": "Stadium",
-        "happiness": 4,
+        "happiness": 2,
         "maintenance": 2,
         "requiredBuilding": "Zoo",
         "requiredTech": "Refrigeration"
@@ -1893,7 +1947,6 @@
         "name": "Cristo Redentor",
         "culture": 5,
         "isWonder": true,
-        "greatPersonPoints": {"Great Artist": 2},        
         "uniques": ["[10]% Culture cost of adopting new Policies"],
         "requiredTech": "Plastics",
         "quote": "'Come to me, all who labor and are heavy burdened, and I will give you rest.'  - New Testament, Matthew 11:28"
@@ -1902,7 +1955,6 @@
         "name": "Kremlin", //adjusted
         "culture": 1,
         "isWonder": true,
-        "greatPersonPoints": {"Great Scientist": 1},    
         "uniques": ["[+50]% Production when constructing [Armor] units [in all cities]","Free Social Policy",
             "Only available <after adopting [Order]>"],
         "requiredTech": "Railroads",
@@ -1915,6 +1967,7 @@
         "gold": 6,
         "greatPersonPoints": {"Great Merchant": 1},
         "isWonder": true,
+        "cost": 750,
         "uniques": ["[+1 Happiness, +2 Culture, +3 Gold] from every [Castle]",
             "Must have an owned [Mountain] within [2] tiles"],
         "requiredTech": "Industrialization",
@@ -1949,7 +2002,7 @@
         "maintenance": 3,
 		"cost": 500,
         "requiredTech": "Ecology",
-        "uniques": ["Provides [2] [Aluminum]"]
+        "uniques": ["Provides [2] [Aluminum]", "Limited to [5] per Civilization"]
     },
     {
         "name": "Solar Plant",
@@ -1995,8 +2048,9 @@
         "requiredTech": "Rocketry"
     },   
     {
-        "name": "National Visitor's Center", 
-		"cost": 400,
+      "name": "National Visitor's Center", 
+		  "cost": 400,
+		  "culture": 1,
         "isNationalWonder": true,
         "uniques": ["[+100]% [Culture] [in this city]","Requires a [Hotel] in all cities"],
         "requiredTech": "Telecommunications"
@@ -2004,10 +2058,10 @@
     {
         "name": "CN Tower", 
         "isWonder": true,
-        "uniques": ["+1 population in each city","[+1 Happiness] [in all cities]","Gain a free [Broadcast Tower] [in this city]"],
+        "greatPersonPoints": {"Great Merchant": 1},
+        "uniques": ["[1] population [in all cities]","[+1 Happiness] [in all cities]","Gain a free [Broadcast Tower] [in this city]"],
         "culture": 1,
         "cost": 1250,
-        "greatPersonPoints": {"Great Engineer": 1},
         "requiredTech": "Radar",
         "quote" : "'Nothing travels faster than the speed of light with the possible exception of bad news, which obeys its own special laws.' - Douglas Adams"
     },
@@ -2015,8 +2069,9 @@
         "name": "Hubble Space Telescope",
         "cost": 1250,
         "isWonder": true,
+        "culture": 1,
 		"science": 10,
-        "greatPersonPoints": {"Great Scientist": 3},        
+        "greatPersonPoints": {"Great Scientist": 3},
         "uniques": ["Gain a free [Recycling Center] [in this city]","[+200]% Production when constructing [Spaceship part] units [in this city]"],
         "requiredTech": "Satellites",
         "quote": "'The wonder is, not that the field of stars is so vast, but that man has measured it.'  - Anatole France"

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -82,295 +82,25 @@
         "uniques": ["Only available <in cities without a [~limit]>","Gain a free [~limit] [in this city]","Will not be displayed in Civilopedia","Provides [2] [Pepper]","Must be next to [Coast]"],
     },
     {
-        "name": "Maya Great People Bonus",
-        "uniqueTo": "The Maya",
-        "greatPersonPoints": {"Great Scientist": 12,"Great Artist": 12,"Great Engineer": 12,"Great Merchant": 12},
-        "requiredTech": "Theology",
-        "cost": 1,
-        "replacementTextForUniques": " ",
-        "uniques": ["Destroyed when the city is captured","Only available <if [Palace] is constructed>",
-        	"Will not be displayed in Civilopedia","Unsellable"]
-    },
-    {
         "name": "~CS",
         "cost": 1,
         "uniques": ["Unsellable","Will not be displayed in Civilopedia","Unbuildable","Destroyed when the city is captured"]
     },
-		    {
-        "name": "Classical Trade Routes",
-        "cost": -1,
-        "uniques": ["Destroyed when the city is captured","Unsellable","[+2 Food] from every [Sea Trade Route (Food)] [in this city]","[+1 Production] from every [Sea Trade Route (Production)] [in this city]","[+2 Gold, +1 Science] from every [Sea Trade Route (Gold)] [in this city]","[+1 Gold, +1 Science] from every [Land Trade Route (Gold)] [in this city]","[+1 Food] from every [Land Trade Route (Food)] [in this city]","[+1 Production] from every [Land Trade Route (Production)] [in this city]","Only available <if [Palace] is constructed>","Only available <starting from the [Classical era]>","Will not be displayed in Civilopedia"]
-    },
-			    {
-        "name": "Renaissance Trade Routes",
-        "cost": -1,
-        "uniques": ["Destroyed when the city is captured","Unsellable","[+2 Food] from every [Sea Trade Route (Food)] [in this city]","[+1 Production] from every [Sea Trade Route (Production)] [in this city]","[+2 Gold, +1 Science] from every [Sea Trade Route (Gold)] [in this city]","[+1 Gold, +1 Science] from every [Land Trade Route (Gold)] [in this city]","[+1 Food] from every [Land Trade Route (Food)] [in this city]","[+1 Production] from every [Land Trade Route (Production)] [in this city]","Only available <if [Palace] is constructed>","Only available <starting from the [Renaissance era]>","Will not be displayed in Civilopedia"]
-    },
-			    {
-        "name": "Modern Trade Routes",
-        "cost": -1,
-        "uniques": ["Destroyed when the city is captured","Unsellable","[+2 Food] from every [Sea Trade Route (Food)] [in this city]","[+1 Production] from every [Sea Trade Route (Production)] [in this city]","[+2 Gold, +1 Science] from every [Sea Trade Route (Gold)] [in this city]","[+1 Gold, +1 Science] from every [Land Trade Route (Gold)] [in this city]","[+1 Food] from every [Land Trade Route (Food)] [in this city]","[+1 Production] from every [Land Trade Route (Production)] [in this city]","Only available <if [Palace] is constructed>","Only available <starting from the [Modern era]>","Will not be displayed in Civilopedia"]
-    },
-	    {
-        "name": "Morocco Classical",
-		        "isNationalWonder": true,
-        "uniqueTo": "Morocoo",
-        "cost": -1,
-        "replacementTextForUniques": " ",
-        "uniques": ["[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)]","[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)]","Only available <if [Palace] is constructed>","Only available <starting from the [Classical era]>","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Morocco Medieval",
-		        "isNationalWonder": true,
-        "uniqueTo": "Morocoo",
-        "cost": -1,
-        "replacementTextForUniques": " ",
-        "uniques": ["[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)]","[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)]","Only available <if [Palace] is constructed>","Only available <starting from the [Medieval era]>","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Morocco Renaissance",
-		        "isNationalWonder": true,
-        "uniqueTo": "Morocoo",
-        "cost": -1,
-        "replacementTextForUniques": " ",
-        "uniques": ["[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)]","[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)]","Only available <if [Palace] is constructed>","Only available <starting from the [Renaissance era]>","Will not be displayed in Civilopedia"]
-    },	    {
-        "name": "Morocco Industrial",
-		        "isNationalWonder": true,
-        "uniqueTo": "Morocoo",
-        "cost": -1,
-        "replacementTextForUniques": " ",
-        "uniques": ["[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)]","[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)]","Only available <if [Palace] is constructed>","Only available <starting from the [Industrial era]>","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Morocco Modern",
-		        "isNationalWonder": true,
-        "uniqueTo": "Morocoo",
-        "cost": -1,
-        "replacementTextForUniques": " ",
-        "uniques": ["[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)]","[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)]","Only available <if [Palace] is constructed>","Only available <starting from the [Modern era]>","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Morocco Atomic",
-		        "isNationalWonder": true,
-        "uniqueTo": "Morocoo",
-        "cost": -1,
-        "replacementTextForUniques": " ",
-        "uniques": ["[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)]","[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)]","Only available <if [Palace] is constructed>","Only available <starting from the [Atomic era]>","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Morocco Information",
-		        "isNationalWonder": true,
-        "uniqueTo": "Morocoo",
-        "cost": -1,
-        "replacementTextForUniques": " ",
-        "uniques": ["[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)]","[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)]","Only available <if [Palace] is constructed>","Only available <starting from the [Information era]>","Will not be displayed in Civilopedia"]
-    },
-	    {
-        "name": "Bonus Trade Routes",
-        "isNationalWonder": true,
-        "cost": 1,
-        "uniques": ["Provides [2] [Trade Route (Count)]","Provides [2] [Trade Route]","Will not be displayed in Civilopedia","Unbuildable"]
-    },
 	    {
         "name": "Castle Builders",
         "cityStrength": 5,
-		"cost": 1,
+		    "cost": 1,
+		    "uniqueTo": "Normandy",
         "uniques": ["Unsellable","Unbuildable","Will not be displayed in Civilopedia"]
     },
 		    {
         "name": "Ulugh Beg's Observatory",
         "cityStrength": 5,
-		"isNationalWonder": true,
-		"percentStatBonus": {"science": 10, "production": 10, "gold": 10, "culture": 10},
-		"cost": 1,
+        "uniqueTo": "Timurids",
+		    "isNationalWonder": true,
+		    "percentStatBonus": {"science": 10, "production": 10, "gold": 10, "culture": 10},
+		    "cost": 1,
         "uniques": ["Unbuildable","Will not be displayed in Civilopedia"]
-    },
-	{
-		"name": "Great Zimbabwe",
-		"cost": 1,
-		"uniques": ["Destroyed when the city is captured","Unsellable","Unbuildable","Will not be displayed in Civilopedia","[+25]% Production when constructing [All] buildings [in this city]","[+25]% Production when constructing [Military] units [in this city]"]
-	}		
-		{
-        "name": "GPBonus",
-		"cost": 1,
-        "uniques": ["Destroyed when the city is captured","[+33]% Great Person generation [in this city]","Unsellable","Unbuildable","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Free Burial Tomb",
-		"uniqueTo": "Ayyubids",
-        "cost": 1,
-        "uniques": ["Gain a free [Burial Tomb] [in this city]","Can only be built [in annexed cities]","Will not be displayed in Civilopedia","Unsellable"]
-    },
-	{
-        "name": "Free Seaport",
-		"uniqueTo": "Oman",
-        "cost": 1,
-        "uniques": ["Gain a free [Seaport] [in this city]","Can only be built [in annexed cities]","Will not be displayed in Civilopedia","Unsellable"]
-    },
-			    {
-        "name": "Free Jarliq",
-		"uniqueTo": "Golden Horde",
-        "cost": 1,
-		"requiredTech": "Philosophy",
-        "uniques": ["Gain a free [Jarliq] [in this city]","Requires a [Palace] [in this city]","Will not be displayed in Civilopedia","Unsellable","Free [Great Artist] appears"]
-    },
-			    {
-        "name": "Boers Bonus",
-		"uniqueTo": "Boers",
-        "cost": 1,
-		"isNationalWonder": true,
-		"requiredTech": "Fertilizer",
-        "uniques": ["[+1 Culture] from every [Farm]","Will not be displayed in Civilopedia"]
-    },
-				    {
-        "name": "The Way of Chumaks",
-		"uniqueTo": "Ukraine",
-        "cost": 1,
-		"isNationalWonder": true,
-		"requiredTech": "The Wheel",
-        "uniques": ["[+1 Food] from every [Maize]","[+1 Food] from every [Wheat]","[+1 Food] from every [Salt]","Will not be displayed in Civilopedia"]
-    },
-					    {
-        "name": "Eightfold Path to Nirvana",
-		"uniqueTo": "Tibet",
-        "cost": 1,
-		"isNationalWonder": true,
-		"requiredTech": "Drama and Poetry",
-        "uniques": ["Will not be displayed in Civilopedia","[+2 Faith, +2 Food, +2 Culture, +2 Production, +2 Science, +2 Gold] <after discovering [Drama and Poetry]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] <after discovering [Education]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] <after discovering [Acoustics]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] <after discovering [Industrialization]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] <after discovering [Radio]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] <after discovering [Radar]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] <after discovering [Telecommunications]>"]
-    },
-				    {
-        "name": "City of Light",
-		"uniqueTo": "France",
-        "cost": 1,
-		"culture": 1,
-		"isNationalWonder": true,
-        "uniques": ["Unbuildable","Requires a [Palace] [in this city]","Will not be displayed in Civilopedia","[+15 Culture] <after discovering [Acoustics]>"]
-    },
-					    {
-        "name": "Italy Liberty",
-		"uniqueTo": "Italy",
-        "cost": 1,
-		"isNationalWonder": true,
-        "uniques": ["Only available <after adopting [Liberty Complete]>","Empire enters golden age","Will not be displayed in Civilopedia"]
-    },
-						    {
-        "name": "Italy Tradition",
-		"uniqueTo": "Italy",
-        "cost": 1,
-		"isNationalWonder": true,
-        "uniques": ["Only available <after adopting [Tradition Complete]>","Empire enters golden age","Will not be displayed in Civilopedia"]
-    },
-						    {
-        "name": "Italy Honor",
-		"uniqueTo": "Italy",
-        "cost": 1,
-		"isNationalWonder": true,
-        "uniques": ["Only available <after adopting [Honor Complete]>","Empire enters golden age","Will not be displayed in Civilopedia"]
-    },
-						    {
-        "name": "Italy Piety",
-		"uniqueTo": "Italy",
-        "cost": 1,
-		"isNationalWonder": true,
-        "uniques": ["Only available <after adopting [Piety Complete]>","Empire enters golden age","Will not be displayed in Civilopedia"]
-    },
-						    {
-        "name": "Italy Commerce",
-		"uniqueTo": "Italy",
-        "cost": 1,
-		"isNationalWonder": true,
-        "uniques": ["Only available <after adopting [Commerce Complete]>","Empire enters golden age","Will not be displayed in Civilopedia"]
-    },
-						    {
-        "name": "Italy Patronage",
-		"uniqueTo": "Italy",
-        "cost": 1,
-		"isNationalWonder": true,
-        "uniques": ["Only available <after adopting [Patronage Complete]>","Empire enters golden age","Will not be displayed in Civilopedia"]
-    },
-						    {
-        "name": "Italy Aesthetics",
-		"uniqueTo": "Italy",
-        "cost": 1,
-		"isNationalWonder": true,
-        "uniques": ["Only available <after adopting [Aesthetics Complete]>","Empire enters golden age","Will not be displayed in Civilopedia"]
-    },
-						    {
-        "name": "Italy Rationalism",
-		"uniqueTo": "Italy",
-        "cost": 1,
-		"isNationalWonder": true,
-        "uniques": ["Only available <after adopting [Rationalism Complete]>","Empire enters golden age","Will not be displayed in Civilopedia"]
-    },
-						    {
-        "name": "Italy Exploration",
-		"uniqueTo": "Italy",
-        "cost": 1,
-		"isNationalWonder": true,
-        "uniques": ["Only available <after adopting [Exploration Complete]>","Empire enters golden age","Will not be displayed in Civilopedia"]
-    },
-	    {
-        "name": "Trade Route1",
-        "isNationalWonder": true,
-        "cost": 1,
-		"requiredTech": "Animal Husbandry",
-        "uniques": ["Only available <in cities without a [~CS]>","Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Trade Route2",
-        "isNationalWonder": true,
-        "cost": 1,
-		"requiredTech": "Sailing",
-        "uniques": ["Only available <in cities without a [~CS]>","Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]","Will not be displayed in Civilopedia"]
-    },
-			    {
-        "name": "Trade Route3",
-        "isNationalWonder": true,
-        "cost": 1,
-		"requiredTech": "Engineering",
-        "uniques": ["Only available <in cities without a [~CS]>","Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Trade Route4",
-        "isNationalWonder": true,
-        "cost": 1,
-		"requiredTech": "Compass",
-        "uniques": ["Only available <in cities without a [~CS]>","Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Trade Route5",
-        "isNationalWonder": true,
-        "cost": 1,
-		"requiredTech": "Banking",
-        "uniques": ["Only available <in cities without a [~CS]>","Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Trade Route6",
-        "isNationalWonder": true,
-        "cost": 1,
-		"requiredTech": "Biology",
-        "uniques": ["Only available <in cities without a [~CS]>","Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Trade Route7",
-        "isNationalWonder": true,
-        "cost": 1,
-		"requiredTech": "Railroads",
-        "uniques": ["Only available <in cities without a [~CS]>","Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]","Will not be displayed in Civilopedia"]
-    },
-		    {
-        "name": "Trade Route8",
-        "isNationalWonder": true,
-        "cost": 1,
-		"requiredTech": "Pharmaceuticals",
-        "uniques": ["Only available <in cities without a [~CS]>","Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]","Will not be displayed in Civilopedia"]
-    },
-			    {
-        "name": "Trade Route9",
-        "isNationalWonder": true,
-        "cost": 1,
-        "uniques": ["Only available <in cities without a [~CS]>","Provides [2] [Trade Route (Count)]","Provides [2] [Trade Route]","Only available <after adopting [Entrepreneurship]>","Will not be displayed in Civilopedia"]
     },
 	
 	// Buildings & Wonders
@@ -391,7 +121,7 @@
 	    {
         "name": "Orszaggyules",
 		"uniqueTo": "Hungary",
-        "isNationalWonder": true,
+        "isNationalWonder": false,
 		"replaces": "Palace",
         "production": 3,
         "science": 3,
@@ -399,7 +129,7 @@
         "cityStrength": 2,
         "culture": 1,
         "cost": 150,
-        "uniques": ["Indicates the capital city","[+25]% Great Person generation [in this city]","[+10]% Production when constructing [All] buildings [in this city]","[+3 Culture, +3 Production, +3 Food] <after discovering [Chivalry]>"]
+        "uniques": ["Indicates the capital city","[+25]% Great Person generation [in this city]","[+10]% Production when constructing [All] buildings [in this city]","Limited to [2] per Civilization"]
 	"requiredTech": "Mathematics",
     },
     {
@@ -843,7 +573,18 @@
 		"gold": 2,
         "uniques": ["[+2 Gold] from [Land Trade Route (Gold)] [in this city]"],
         "requiredTech": "Horseback Riding"
-    }
+    },
+	    {
+        "name": "Yam Route",
+		"replaces": "Caravansary",
+		"uniqueTo": "Golden Horde",
+		"science": 3,
+		"cost": 120,
+		"science": 3,
+        "hurryCostModifier": 25,
+        "uniques": ["[+2 Gold] from [Land Trade Route (Gold)] [in this city]"],
+        "requiredTech": "Horseback Riding"
+    },
 	    {
 		"name": "Serai",
 		"uniqueTo": "Timurids",
@@ -940,18 +681,6 @@
         "uniques": ["Remove extra unhappiness from annexed cities",
             "Can only be built [in annexed cities]"],
         "requiredTech": "Mathematics"
-    },
-	    {
-        "name": "Jarliq",
-		"replaces": "Courthouse",
-		"uniqueTo": "Golden Horde",
-		"gold": 3,
-		"cost": 100,
-		"science": 3,
-        "hurryCostModifier": 50,
-        "uniques": ["Remove extra unhappiness from annexed cities",
-            "Can only be built [in annexed cities]","Unsellable","Free [Great Artist] appears"],
-        "requiredTech": "Writing"
     },
     {
         "name": "Colosseum", 

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -1313,7 +1313,7 @@
 		"outerColor": [254,204,32],
 		"innerColor": [0,55,106],
 		"uniqueName": "Eight Banners",
-		"uniques": ["[-100]% maintenance costs <for [Mounted Ranged] units>", "[-100]% maintenance costs <for [Mounted] units>", "[-100]% maintenance costs <for [Armor] units>", "[Mounted Ranged] units gain the [Volley] promotion","[Mounted] units gain the [Volley] promotion","[Armor] units gain the [Volley] promotion","[+100]% Production when constructing [Stable] buildings [in all cities]", "[+1 Gold] from every [Stable]",
+		"uniques": ["[-100]% maintenance costs <for [Mounted Ranged] units>", "[-100]% maintenance costs <for [Mounted] units>", "[-100]% maintenance costs <for [Armor] units>", "[Mounted Ranged] units gain the [Volley] promotion","[Mounted] units gain the [Volley] promotion","[Armor] units gain the [Volley] promotion","[+100]% Production when constructing [Stable] buildings [in all cities]", "[+1 Gold] from every [Stable]"],
 		"cities": ["Mukden","Hetu Ala","Yenden","Xingjing","Fushun","Qinghe","Sarhu","Girin Ula","Qiaonan","Tieling","Ningdota","Siping","Anshan"]
 	},
 		{
@@ -1499,7 +1499,7 @@
 		"outerColor": [254,135,0],
 		"innerColor": [255,255,255],
 		"uniqueName": "Dutch East India Company",
-		"uniques": ["[+1 Gold] from every [Luxury resource]", "[1] Happiness from each type of luxury resource]"],
+		"uniques": ["[+1 Gold] from every [Luxury resource]", "[1] Happiness from each type of luxury resource"],
 		"cities": ["Amsterdam","Rotterdam","Utrecht","Groningen","Breda","Nijimegen","Den Haag","Haarlem","Arnhem","Zutphen",
 			"Maastricht","Tilburg","Eindhoven","Dordrecht","Leiden","Hertogenbosch","Almere","Alkmaar","Brielle","Vlissingen",
 			"Apeldoorn","Nova Enschede","Sao Bernardo do Amersfoort","Zwolle","Venlo","Uden","Grave","Delft","Gouda","Nieuwstadt",
@@ -1876,7 +1876,7 @@
 		"outerColor": [5,60,77],
 		"innerColor": [201,214,217],
 		"uniqueName": "Flower of Scotland",
-		"uniques": ["[+2 Culture, +2 Science, +2 Production] from every [Writer Guild]","[+2 Culture, +2 Science, +2 Production] from every [Artist Guild]","[+2 Culture, +2 Science, +2 Production] from every [Musician Guild]","[+33]% Great Person generation [in capital]",
+		"uniques": ["[+2 Culture, +2 Science, +2 Production] from every [Writer Guild]","[+2 Culture, +2 Science, +2 Production] from every [Artist Guild]","[+2 Culture, +2 Science, +2 Production] from every [Musician Guild]","[+33]% Great Person generation [in capital]"],
 		"cities": ["Edinbourgh","Glasgow","Stirling","Aberdeen","Dundee","Inverness","Perth","Dunfermline","Kilmarnock","Dumfries","Lanark","Dumbarton","Falkirk"]
 	},
 	{
@@ -1969,7 +1969,7 @@
 		"hateHello": "What do you want?",
 		"tradeRequest": "Better hurry, I may change my mind.",
 		"outerColor": [255,120,0],
-		"innerColor": [77,/32,32],
+		"innerColor": [77,32,32],
 		"uniqueName": "Dwellers of the Plains",
 		"uniques": ["[+15]% Strength <for [Military] units> <in [Plains] tiles>"],
 		"cities": ["Ihankthunwanna","Bdewekhanthunwan","Isanyathi","Sichangju","Oglala","Itazipcho","Assiniboine","Sisithunwan","Wahpekhute","Wahpethunwan","Hunkpapha","Mnikhowozu","Sihasapa"]
@@ -2244,7 +2244,7 @@
 		"outerColor": [70,70,82],
 		"innerColor": [205,146,68],
 		"uniqueName": "Great Zimbabwe",
-		"uniques": ["[+25]% Production when constructing [All] buildings [in capital]","[+25]% Production when constructing [Military] units [in in capital]"],
+		"uniques": ["[+25]% Production when constructing [All] buildings [in capital]","[+25]% Production when constructing [Military] units [in capital]"],
 		"cities": ["Great Zimbabwe","Khami","Zvongombe","Danamombe","MApangubwe","Mayenne","Harare","Bulawayo","Chitungwiza","Mutare","Epworth","Gweru","Kwekwe","Kadoma"]
 	},
 	{

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -241,8 +241,7 @@
 		"outerColor": [221, 141, 0],
 		"innerColor": [255, 244, 174],
 		"uniqueName": "Justice of Saladin",
-		"uniqueText": "All cities receive a free Burial Tomb upon capture. Workers create improvements 25% faster",
-		"uniques": ["[-25]% tile improvement construction time"],
+		"uniques": ["[-25]% tile improvement construction time","Gain a free [Burial Tomb] [in annexed cities]"],
 		"cities": ["Al-Quahirah","Al-Iskandariyyah","B'Albek","Assuan","Bilbeis","Dimashq","Qus","Adan","Zabid","Beirut","Akhmim","Al-Karak","Madinat Al-Fayyum"]
 	},
 	{
@@ -264,7 +263,6 @@
 		"outerColor": [139,32,23],
 		"innerColor": [134,238,214],
 		"uniqueName": "Sacrificial Captives",
-		"uniqueText": "Gains Culture for the empire from each enemy unit killed",
 		"uniques": ["Earn [100]% of killed [Military] unit's [Strength] as [Culture]"],
 		"cities": ["Tenochtitlan","Teotihuacan","Tlatelolco","Texcoco","Tlaxcala","Calixtlahuaca","Xochicalco","Tlacopan",
 			"Atzcapotzalco","Tzintzuntzan","Malinalco","Tula","Tamuin","Teayo","Cempoala","Chalco","Tlalmanalco",
@@ -339,8 +337,7 @@
 		"outerColor": [228, 111, 87],
 		"innerColor": [38, 41, 80],
 		"uniqueName": "The Great Trek",
-		"uniqueText": "+2 food in all cities before Civil Service, +1 culture from farms after the discovery of Fertilizer",
-		"uniques": ["[+2 Food] [in all cities] <before discovering [Civil Service]>"],
+		"uniques": ["[+1 Food] from every [Farm] <in [non-fresh water] tiles>", "[+1 Culture] from every [Farm] <after discovering [Fertilizer]>"],
 		"cities": ["Pretoria","Bloemfontein","Johannesburg","Pietermatitzburg","Klerksdorp","Pietersburg","Potchefstroom","Vryburg","Winburg","Bloemhof","Benoni","Boksburg"]
 	},
 	{
@@ -451,7 +448,7 @@
 		"outerColor": [88,145,228],
 		"innerColor": [80,23,135],
 		"uniqueName": "Patriarchate of Constantinople",
-		"uniques": ["[+2 Culture, +2 Gold, +1 Production, +1 Science, +1 Faith] [in capital]"],
+		"uniques": ["May choose [1] additional belief(s) of any type when [founding] a religion"],
 		"cities": ["Constantinople","Adrianople","Nicaea","Antioch","Varna","Ohrid","Nicomedia","Trebizond","Cherson","Sardica",
 			"Ani","Dyrrachium","Edessa","Chalcedon","Naissus","Bari","Iconium","Prilep","Samosata","Kars",
 			"Nicopolis","Theodosiopolis","Tyana","Gaza","Kerkyra","Phoenice","Selymbria","Sillyon","Chrysopolis","Vodena",
@@ -696,8 +693,7 @@
 		"outerColor": [ 38, 98, 255],
 		"innerColor": [239,236,148],
 		"uniqueName": "City of Light",
-		"uniqueText": "+1 Culture in capital, additional +15 Culture upon researching Acoustics. +25% Culture in capital",
-		"uniques": ["[+25]% [Culture] [in capital]","Gain a free [City of Light] [in capital]"],
+		"uniques": ["[+25]% [Culture] [in capital]", "[+1 Culture] [in capital]","[+15 Culture] [in capital] <after discovering [Acoustics]>"],
 		"cities": ["Paris","Orleans","Lyon","Troyes","Tours","Marseille","Chartres","Avignon","Rouen","Grenoble",
 			"Dijon","Amiens","Cherbourg","Poitiers","Toulouse","Bayonne","Strasbourg","Brest","Bordeaux","Rennes",
 			"Nice","Saint Etienne","Nantes","Reims","Le Mans","Montpellier","Limoges","Nancy","Lille","Caen","Toulon",
@@ -792,7 +788,7 @@
 		"outerColor": [55,25,8],
 		"innerColor": [156,197,237],
 		"uniqueName": "Golden Conquest",
-		"uniques": ["Receive a free Great Artist upon completing a Jarliq in a City. After the discovery of Philosophy, receive a free Jarliq in the Capital"],
+		"uniques": ["[+50]% [Production] [in puppeted cities]", "[+50]% [Gold] [in puppeted cities]", "[+50]% [Science] [in puppeted cities]", "[-50]% Unhappiness from [Population] [in puppeted cities]"],
 		"cities": ["Sarai Batu","Sarai Berke","Kazan","Almaty","Makhachkala","Sarai Juk","Ufa","Astana","Itil","Tsaritsyn","Narchik","Aqtobe","Aqtau"]
 	},
 					{
@@ -906,7 +902,6 @@
 		"outerColor": [53, 244, 72],
 		"innerColor": [255, 41, 13],
 		"uniqueName": "Verszerzodes",
-		"uniqueText": "Walls, Castles, Arsenals and Military Bases provide +1 Production and Culture",
 		"uniques": ["[+1 Production, +1 Culture] from every [Walls]","[+1 Production, +1 Culture] from every [Castle]","[+1 Production, +1 Culture] from every [Arsenal]","[+1 Production, +1 Culture] from every [Military Base]"],
 		"cities": ["Buda","Pest","Bratislava","Szeged","Szekesfehervar","Debrecen","Pecs","Miskolc","Esztergom","Visegrad","Temesvar","Obuda","Gyor"]
 	},
@@ -1095,7 +1090,7 @@
 		"outerColor": [41, 87, 0],
 		"innerColor": [205, 205, 205],
 		"uniqueName": "Rinascimento",
-		"uniques": ["[+1 Culture] from every specialist [in all cities]","Enter a Golden Age upon completion of a Policy Tree."],
+		"uniques": ["[+1 Culture] from every specialist [in all cities]", "Empire enters golden age <upon adopting [Tradition Complete]>" ,"Empire enters golden age <upon adopting [Liberty Complete]>", "Empire enters golden age <upon adopting [Honor Complete]>", "Empire enters golden age <upon adopting [Piety Complete]>", "Empire enters golden age <upon adopting [Aesthetics Complete]>", "Empire enters golden age <upon adopting [Patronage Complete]>", "Empire enters golden age <upon adopting [Exploration Complete]>", "Empire enters golden age <upon adopting [Commerce Complete]>", "Empire enters golden age <upon adopting [Rationalism Complete]>"],
 		"cities": ["Roma","Milan","Naples","Turin","Florence","Genoa","Bari","Palermo","Cagliari","Catania","Brescia","Messina","Pisa","Bologna","Verona"]
 	},
 	{
@@ -1279,7 +1274,6 @@
 		"outerColor": [92,60,83],
 		"innerColor": [220,190,92],
 		"uniqueName": "Macedonian Discipline",
-		"uniqueText": "Barracks, Armories, and Military Academies provide +1 Food and +1 Culture. Receive a free Hetairoi at Horseback Riding.",
 		"uniques": ["Receive free [Hetairoi] when you discover [Horseback Riding]","[+1 Food, +1 Culture] from every [Barracks]","[+1 Food, +1 Culture] from every [Military Academy]","[+1 Food, +1 Culture] from every [Armory]"],
 		"cities": ["Pella","Vergina","Amphipolis","Larissa","Ambracia","Methoni","Olynthus","Patidea","Philippopolis","Alexandropolis","Alexandria","Alexandria Latmus","Alexandria Issus","Alexandria Ariana"]
 	},
@@ -1368,7 +1362,7 @@
 		"outerColor": [213,166,120],
 		"innerColor": [43,79,83],
 		"uniqueName": "The Long Count",
-		"uniqueText": "After researching Theology, receive a bonus Great Person at the end of every Maya Long Count calendar cycle (every 394 years)",
+		"uniques": ["After researching Theology, receive a bonus Great Person at the end of every Maya Long Count calendar cycle (every 394 years)","Once The Long Count activates, the year on the world screen displays as the traditional Mayan Long Count."],
 		"cities": ["Palenque","Tikal","Chichen Itza","Uxmal","Tulum","Copan","Coba","El Mirador","Calakmul","Edzna",
 			"Lamanai","Izapa","Uaxactun","Comalcalco","Piedras Negras","Cancuen","Yaxha","Quirigua","Q'umarkaj","Nakbe",
 			"Cerros","Xumantunich","Takalik Abaj","Cival","San Bartolo","Altar de Sacrificios","Seibal","Caracol","Naranjo","Dos Pilas",
@@ -1463,7 +1457,7 @@
 		"innerColor": [40,179,79],
 		"uniqueName": "Gateway to Africa",
 		"uniqueText": "+3 Gold and +1 Culture from every gold Trade Route, bonus inceases by +1 Gold and +1 Culture each era",
-		"uniques": ["[+3 Gold, +1 Culture] from every [Land Trade Route (Gold)]","[+3 Gold, +1 Culture] from every [Sea Trade Route (Gold)]"],
+		"uniques": ["[+3 Gold, +1 Culture] from every [Land Trade Route (Gold)]", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Classical era]>","[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Medieval era]>", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Renaissance era]>", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Industrial era]>", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Modern era]>", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Atomic era]>", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Information era]>", "[+3 Gold, +1 Culture] from every [Sea Trade Route (Gold)]", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Classical era]>","[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Medieval era]>", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Renaissance era]>", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Industrial era]>", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Modern era]>", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Atomic era]>", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Information era]>"],
 		"cities": ["Marrakech","Rabat","Fes","Casablanca","Tangier","Salé","Quarzazate","Meknes","Agadir","Oujda",
 			"Kenitra","Tetouan","Essaouira","Safi","Taroudannt","Mohammedia","El Aaiun","Beni Mellal","El Jadida","Ksar el Kebir",
 			"Taza","Fquih ben Salah","Khouribga","Nador","Settat","Berrechid","Larache","Khemisset","Guelmim","Dakhla",
@@ -1604,7 +1598,7 @@
 		"innerColor": [211,204,27],
 		"uniqueName": "Chain of the Earth",
 		"uniqueText": "All Naval Units ignore Zone of Control movement penalties. Receive a free Seaport in captured Cities",
-		"uniques": ["[Water] units gain the [Chain of the Earth] promotion"],
+		"uniques": ["[Water] units gain the [Chain of the Earth] promotion", "Gain a free [Seaport] [in annexed cities]"],
 		"cities": ["Muscat","Salalah","Nizwa","Sur","Ibra","Bahla","Rustaq","Barka","Muttrah","Sahar","Sahan","Samail","Khasab","Raysut","Jabrin","Al Hamra","Seeb","Duqm"]
 	},
 	{
@@ -1698,7 +1692,7 @@
 		"outerColor": [177,55,73],
 		"innerColor": [234,201,52],
 		"uniqueName": "Skillful Traders",
-		"uniques": ["Gain a free [Bonus Trade Routes] [in capital]","Receive free [Square Sail Ship] when you discover [Pottery]"],
+		"uniques": ["Provides [2] [Trade Route (Count)]", "Provides [2] [Trade Route]","Receive free [Square Sail Ship] when you discover [Pottery]"],
 		"cities": ["Tyre","Sidon","Ugarit","Berytus","Byblos","Arvad","Kition","Tripolis","Baalbek","Sarepta","Dor","Orthosias"]
 	},
 	{
@@ -1891,7 +1885,7 @@
 		"innerColor": [201,214,217],
 		"uniqueName": "Flower of Scotland",
 		"uniqueText": "+3 Culture, +3 Science, +3 Production from Grand Temple and Hermitage, +33% faster Great Person generation in the Capital.",
-		"uniques": ["[+3 Culture, +3 Science, +3 Production] from every [Grand Temple]","[+3 Culture, +3 Science, +3 Production] from every [Hermitage]","Gain a free [GPBonus] [in capital]"],
+		"uniques": ["[+3 Culture, +3 Science, +3 Production] from every [Grand Temple]","[+3 Culture, +3 Science, +3 Production] from every [Hermitage]","[+33]% Great Person generation [in capital]",
 		"cities": ["Edinbourgh","Glasgow","Stirling","Aberdeen","Dundee","Inverness","Perth","Dunfermline","Kilmarnock","Dumfries","Lanark","Dumbarton","Falkirk"]
 	},
 	{
@@ -2081,7 +2075,7 @@
 		"innerColor": [39,167,95],
 		"uniqueName": "Eightfold Path to Nirvana",
 		"uniqueText": "Receive +2 Food, Production, Gold, Culture and Science in the capital upon the discovery of Drama and Poetry. +1 to those yields at Education, Acoustics, Industrialization, Radio, Radar and Telecommunications",
-		"uniques": ["Gain a free [Eightfold Path to Nirvana] [in capital]"],
+		"uniques": ["[+2 Faith, +2 Food, +2 Culture, +2 Production, +2 Science, +2 Gold] [in capital] <after discovering [Drama and Poetry]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] [in capital] <after discovering [Education]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] [in capital] <after discovering [Acoustics]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] [in capital] <after discovering [Industrialization]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] [in capital] <after discovering [Radio]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] [in capital] <after discovering [Radar]>","[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] [in capital] <after discovering [Telecommunications]>"],
 		"cities": ["Lhasa","Xigaze","Qamdo","Nagqu","Nyingchi","Ngari","Lhoka","Chengguan","Doilungdeqen","Lhunzhub","Damxung","Maizhokunggar","Quxu"]
 	},
 				{
@@ -2175,6 +2169,7 @@
 		"innerColor": [255,233,142],
 		"uniqueName": "The Way of Chumaks",
 		"uniqueText": "+1 Food from Maize, Wheat and Salt resources after researching The Wheel, +2 Gold from each city connected to capital",
+		"uniques": ["[+1 Food] from every [Maize] <after discovering [The Wheel]>","[+1 Food] from every [Wheat] <after discovering [The Wheel]>","[+1 Food] from every [Salt] <after discovering [The Wheel]>", "[+2 Gold] from each Trade Route"]
 		"cities": ["Kiev","Kharkiv","Zaporizhia","Odessa","Dnipropetrovsk","Donetsk","Luhansk","Zhytomyr","Lviv","Kryvyi Rih","Chernihiv","Mariupol","Mykolaiv"]
 	},
 	{
@@ -2266,7 +2261,7 @@
 		"innerColor": [205,146,68],
 		"uniqueName": "Great Zimbabwe",
 		"uniqueText": "+25% Production when constructing buildings and military units in capital.",
-		"uniques": ["Gain a free [Great Zimbabwe] [in capital]"],
+		"uniques": ["[+25]% Production when constructing [All] buildings [in capital]","[+25]% Production when constructing [Military] units [in in capital]"],
 		"cities": ["Great Zimbabwe","Khami","Zvongombe","Danamombe","MApangubwe","Mayenne","Harare","Bulawayo","Chitungwiza","Mutare","Epworth","Gweru","Kwekwe","Kadoma"]
 	},
 	{

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -24,8 +24,7 @@
 		"outerColor": [84, 103, 159],
 		"innerColor": [181, 142, 43],
 		"uniqueName": "The Great Unification",
-		"uniqueText": "+3 Culture, +2 Happiness and +1 Production from conquered cities. Land units have +15% Combat Bonus in combat with Cities.",
-		"uniques": ["[+2 Happiness, +3 Culture, +1 Production] from every [Courthouse]","[Land] units gain the [Epic of Battle] promotion"],
+		"uniques": ["[+2 Happiness, +3 Culture, +1 Production] [in annexed cities]","[+15]% Strength <for [Land] units> <vs cities>"],
 		"cities": ["Akkad","Sipar","Kish","Tell Brak","Nippur","Tell Leilan","Marad","Umma","Azupiranu","Nuzi","Eshnunna"]
 	},
 		{
@@ -47,7 +46,7 @@
 		"outerColor": [17, 31, 99],
 		"innerColor": [186, 139, 20],
 		"uniqueName": "Saint Elesbaan's Blessing",
-		"uniques": ["[+34]% Natural religion spread [in all cities]","[+1 Production, +2 Faith] from every [Quarry]"],
+		"uniques": ["[+34]% Natural religion spread [in all cities]","[+1 Production, +2 Faith] from every [Quarry]", "[+1 Faith] from every [Quarry] <after discovering [Theology]>"],
 		"cities": ["Aksum","Adulis","Tiya","Qohaito","Berbera","Melazo","Tokonda","Yeha","Zeila","Massawa","Matara","Deira","Hawulti"]
 	},
 	{
@@ -191,7 +190,7 @@
 		"outerColor": [0, 91, 65],
 		"innerColor": [225, 148, 26],
 		"uniqueName": "Dreamtime",
-		"uniques": ["[+5 Faith] from every [Natural Wonder]"],
+		"uniques": ["[+5 Faith] from every [Natural Wonder]", "[+10 Faith] <upon discovering a Natural Wonder>"],
 		"cities": ["Canberra","Melbourne","Sydney","Perth","Brisbane","Newcastle","Adelaide","Wollongong","Gold Coast","Sunshine Coast","Hobart"]
 	},
 	{
@@ -384,7 +383,7 @@
 		"outerColor": [7, 0, 54],
 		"innerColor": [228, 134, 228],
 		"uniqueName": "Austronesian Thalassocracy",
-		"uniques": ["[+1 Gold] from every [Coast]","[+1 Gold] from every [Ocean]"],
+		"uniques": ["May heal outside of friendly territory <for [Water] units>"],
 		"cities": ["Bandar Brunei","Manila","Sulu","Cebu","Maguindanao","Sarawak","Namayan","Tondo","Mal-I","Madja-As","Butuan","Lanao","Dapitan"]
 	},
 	{
@@ -406,7 +405,7 @@
 		"outerColor": [125, 71, 113],
 		"innerColor": [82, 19, 36],
 		"uniqueName": "Cyrillic Script",
-		"uniques": ["[+1 Science] [in all cities]","[+1 Culture] from all [Science] buildings"],
+		"uniques": ["[+3 Science] from every [Artist]","[+1 Culture] from all [Science] buildings"],
 		"cities": ["Pliska","Preslav","Tarnovo","Plovdiv","Prilep","Sofia","Vidin","Nis","Kastoria","Skopje","Ohrid","Glavinitsa","Varna"]
 	},
 		{
@@ -495,7 +494,6 @@
 		"outerColor": [189,189,189],
 		"innerColor": [88,0,154],
 		"uniqueName": "Phoenician Heritage",
-		"uniqueText": "All coastal Cities gain a free Harbor. Units may cross mountains, taking 50 HP damage if they end a turn on a mountain",
 		"uniques": ["Gain a free [Harbor] [in all coastal cities]","[Land] units gain the [Phoenician Heritage] promotion"],
 		"cities": ["Carthage","Utique","Hippo Regius","Gades","Saguntum","Carthago Nova","Panormus","Lilybaeum","Hadrumetum","Zama Regia",
 			"Karalis","Malaca","Leptis Magna","Hippo Diarrhytus","Motya","Sulci","Leptis Parva","Tharros","Soluntum","Lixus",
@@ -521,7 +519,7 @@
 		"outerColor": [22,101,63],
 		"innerColor": [148,170,255],
 		"uniqueName": "Druidic Lore",
-		"uniques": ["[+1 Culture] from every [Forest]"],
+		"uniques": ["[+1 Faith] from every [Forest]", "[+1 Faith] from every [Forest] <with [3] to [6] neighboring [Forest] tiles>"],
 		"cities": ["Edinburgh","Dublin","Cardiff","Truro","Nantes","Douglas","Glasgow","Cork","Aberystwyth","Penzance",
 			"Rennes","Ramsey","Inverness","Limerick","Swansea","St. Ives","Brest","Peel","Aberdeen","Belfast",
 			"Caernafon","Newquay","Saint-Nazarre","Castletown","Stirling","Galway","Conwy","St. Austell","Saint-Malo",
@@ -657,8 +655,7 @@
 		"name": "Finland",
 		"leaderName": "Mannerheim",
 		"adjective": ["Finnish"],
-//		"startBias": ["Coast"],
-//		"preferredVictoryType": "Diplomatic",
+		"preferredVictoryType": "Diplomatic",
 
 		"startIntroPart1": " ",
 		"startIntroPart2": " ",
@@ -672,7 +669,7 @@
 		"outerColor": [10, 40, 74],
 		"innerColor": [218, 218, 218],
 		"uniqueName": "Finnish Mobility",
-		"uniques": ["[+1 Culture] [in all cities]","[+10]% combat bonus for [Non-City] units fighting in [Friendly Land]"],
+		"uniques": ["[+1 Culture] from every [Forest]","[+10]% combat bonus for [Non-City] units fighting in [Friendly Land]"],
 		"cities": ["Helsinki","Turku","Porvoo","Tampere","Rauma","Naantali","Viipuri","Pori","Ulvila","Oulu","Vaasa","Uusukaipunki","Kakisalmi"]
 	},
 	{
@@ -740,7 +737,7 @@
 		"outerColor": [99, 88, 32],
 		"innerColor": [138, 199, 125],
 		"uniqueName": "Oppidum of Bibracte",
-		"uniques": ["Gain a free [Murus Gallicus] [in capital]"],
+		"uniques": ["Gain a free [Murus Gallicus] [in capital] <upon discovering [Mining]>"],
 		"cities": ["Bibracte","Gergovia","Tolosa","Lugdunum","Durocortorum","Bagacum","Nemetocenna","Luteria","Samarobriva","Entremont","Burdigala","Nemausus","Vienne"]
 	},
 	{
@@ -810,8 +807,7 @@
 		"outerColor": [29, 26, 26],
 		"innerColor": [181, 214, 207],
 		"uniqueName": "Drauhtinon",
-		"uniqueText": "Melee units receive +1 Movement and heal 25 HP after killing an enemy.",
-		"uniques": ["[Melee] units gain the [Drauhtinon] promotion"],
+		"uniques": ["[+1] Movement <for [Melee] units>"],
 		"cities": ["Arheimar","Aujum","Potaissa","Apulon","Tyras","Sarmizegetusa","Argidava","Olite","Tolosa","Olbia","Reccopolis","Toletum","Pityus"]
 	},
 	{
@@ -832,7 +828,7 @@
 		"outerColor": [181, 232, 232],
 		"innerColor": [68,142,249],
 		"uniqueName": "Hellenic League",
-		"uniques": ["[-50]% City-State Influence degradation","City-State Influence recovers at twice the normal rate","City-State territory always counts as friendly territory"],
+		"uniques": ["[-50]% City-State Influence degradation","City-State Influence recovers at twice the normal rate"],
 		"cities": ["Athens","Sparta","Corinth","Argos","Knossos","Mycenae","Pharsalos","Ephesus","Halicarnassus","Rhodes",
 			"Eretria","Pergamon","Miletos","Megara","Phocaea","Sicyon","Tiryns","Samos","Mytilene","Chios",
 			"Paros","Elis","Syracuse","Herakleia","Gortyn","Chalkis","Pylos","Pella","Naxos","Sicyon",
@@ -1227,13 +1223,12 @@
 		"outerColor": [26,32,96],
 		"innerColor": [255,0,0],
 		"uniqueName": "Scholars of the Jade Hall",
-		"uniques": ["[+1 Science] from every specialist [in all cities]","[+1 Science] [in capital]","[+2 Science] from every [Great Improvement]",
-			"Receive a tech boost when scientific buildings/wonders are built in capital"],
+		"uniques": ["[+1 Science] from every specialist [in all cities]","[+1 Science] [in capital]","[+2 Science] from every [Great Improvement]"],
 		"cities": ["Seoul","Busan","Jeonju","Daegu","Pyongyang","Kaesong","Suwon","Gwangju","Gangneung","Hamhung","Wonju","Ulsan",
 			"Changwon","Andong","Gongju","Haeju","Cheongju","Mokpo","Dongducheon","Geoje","Suncheon","Jinju","Sangju",
 			"Rason","Gyeongju","Chungju","Sacheon","Gimje","Anju"]
 	},
-						{
+	{
 		"name": "Lithuania",
 		"leaderName": "Vytautas",
 		"adjective": ["Lithuania"],
@@ -1255,7 +1250,7 @@
 		"uniques": ["All Great Prophets generated by Lithuania become the Krivis, which can create the Sacred Grove"],
 		"cities": ["Vilnius","Kaunas","Polotsk","Minsk","Voruta","Klaipeda","Vitebsk","Trakai","Mstsislau","Navahrudak","Raseiniai","Kernave","Siauliai","Panevezys","Alytus"]
 	},
-							{
+	{
 		"name": "Macedonia",
 		"leaderName": "Alexander",
 		"adjective": ["Macedonian"],
@@ -1274,10 +1269,10 @@
 		"outerColor": [92,60,83],
 		"innerColor": [220,190,92],
 		"uniqueName": "Macedonian Discipline",
-		"uniques": ["Receive free [Hetairoi] when you discover [Horseback Riding]","[+1 Food, +1 Culture] from every [Barracks]","[+1 Food, +1 Culture] from every [Military Academy]","[+1 Food, +1 Culture] from every [Armory]"],
+		"uniques": ["Receive free [Hetairoi] when you discover [Horseback Riding]","[+1 Food, +1 Culture, +1 Happiness] from every [Barracks]","[+1 Food, +1 Culture, +1 Happiness] from every [Military Academy]","[+1 Food, +1 Culture, +1 Happiness] from every [Armory]"],
 		"cities": ["Pella","Vergina","Amphipolis","Larissa","Ambracia","Methoni","Olynthus","Patidea","Philippopolis","Alexandropolis","Alexandria","Alexandria Latmus","Alexandria Issus","Alexandria Ariana"]
 	},
-								{
+	{
 		"name": "Madagascar",
 		"leaderName": "Ralambo",
 		"adjective": ["Madagascar"],
@@ -1318,7 +1313,7 @@
 		"outerColor": [254,204,32],
 		"innerColor": [0,55,106],
 		"uniqueName": "Eight Banners",
-		"uniques": ["[-100]% maintenance costs <for [Mounted Ranged] units>", "[-100]% maintenance costs <for [Mounted] units>","[Mounted Ranged] units gain the [Volley] promotion","[Mounted] units gain the [Volley] promotion","[Armor] units gain the [Volley] promotion"],
+		"uniques": ["[-100]% maintenance costs <for [Mounted Ranged] units>", "[-100]% maintenance costs <for [Mounted] units>", "[-100]% maintenance costs <for [Armor] units>", "[Mounted Ranged] units gain the [Volley] promotion","[Mounted] units gain the [Volley] promotion","[Armor] units gain the [Volley] promotion","[+100]% Production when constructing [Stable] buildings [in all cities]", "[+1 Gold] from every [Stable]",
 		"cities": ["Mukden","Hetu Ala","Yenden","Xingjing","Fushun","Qinghe","Sarhu","Girin Ula","Qiaonan","Tieling","Ningdota","Siping","Anshan"]
 	},
 		{
@@ -1340,7 +1335,7 @@
 		"outerColor": [42,34,0],
 		"innerColor": [146,129,55],
 		"uniqueName": "Insriptions of the Dharma",
-		"uniqueText": "All non-Air Units receive a -15% Combat Penalty when attacking, a +15% Combat Bonus when defending, and heal 10 HP more every turn in your own territory",
+		"uniqueText": "All non-Air Units receive a -15% Combat Penalty when attacking, a +15% Combat Bonus when defending",
 		"uniques": ["[Land] units gain the [Dharma] promotion","[Water] units gain the [Dharma] promotion"],
 		"cities": ["Pataliputra","Sarnath","Ujjain","Mathura","Indraprastha","Suvarnagiri","Tamralipti","Varanasi","Lumbini","Toshali","Sanchi","Kausambi","Amaravati","Lauriya-Araraj","Bodh Gaya","Sopara","Lalitapatna"]
 	},
@@ -1457,7 +1452,7 @@
 		"innerColor": [40,179,79],
 		"uniqueName": "Gateway to Africa",
 		"uniqueText": "+3 Gold and +1 Culture from every gold Trade Route, bonus inceases by +1 Gold and +1 Culture each era",
-		"uniques": ["[+3 Gold, +1 Culture] from every [Land Trade Route (Gold)]", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Classical era]>","[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Medieval era]>", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Renaissance era]>", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Industrial era]>", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Modern era]>", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Atomic era]>", "[+1 Gold +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Information era]>", "[+3 Gold, +1 Culture] from every [Sea Trade Route (Gold)]", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Classical era]>","[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Medieval era]>", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Renaissance era]>", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Industrial era]>", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Modern era]>", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Atomic era]>", "[+1 Gold +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Information era]>"],
+		"uniques": ["[+4 Gold, +2 Culture] from every [Land Trade Route (Gold)]", "[+1 Gold] from every [Land Trade Route (Gold)] <starting from the [Classical era]>","[+1 Gold] from every [Land Trade Route (Gold)] <starting from the [Medieval era]>", "[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Renaissance era]>", "[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Industrial era]>", "[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Modern era]>", "[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Atomic era]>", "[+1 Gold, +1 Culture] from every [Land Trade Route (Gold)] <starting from the [Information era]>", "[+4 Gold, +2 Culture] from every [Sea Trade Route (Gold)]", "[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Classical era]>","[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Medieval era]>", "[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Renaissance era]>", "[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Industrial era]>", "[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Modern era]>", "[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Atomic era]>", "[+1 Gold, +1 Culture] from every [Sea Trade Route (Gold)] <starting from the [Information era]>"],
 		"cities": ["Marrakech","Rabat","Fes","Casablanca","Tangier","Salé","Quarzazate","Meknes","Agadir","Oujda",
 			"Kenitra","Tetouan","Essaouira","Safi","Taroudannt","Mohammedia","El Aaiun","Beni Mellal","El Jadida","Ksar el Kebir",
 			"Taza","Fquih ben Salah","Khouribga","Nador","Settat","Berrechid","Larache","Khemisset","Guelmim","Dakhla",
@@ -1482,7 +1477,6 @@
 		"outerColor": [47,95,47],
 		"innerColor": [249,249,20],
 		"uniqueName": "Brahmin Elite",
-		"uniqueText": "Specialists provide +1 Food and Production, but generate +50% more Unhappiness",
 		"uniques": ["[+1 Food, +1 Production] from every specialist [in all cities]","[+50]% Unhappiness from [Specialists] [in all cities]"],
 		"cities": ["Mysuru","Hunsur","Bannur","Bengaluru","Nanjanagudu","Periyapatna","Saligrama","Virajpet","Madikeri","Mandya","Maddur","Nagamangala","Narasipura","Arkalgud","Hassan","Belur","Turuvekere","Mudigere","Koppa"]
 	},
@@ -1505,7 +1499,7 @@
 		"outerColor": [254,135,0],
 		"innerColor": [255,255,255],
 		"uniqueName": "Dutch East India Company",
-		"uniques": ["[+1 Gold, +1 Happiness] from every [Luxury resource]"],
+		"uniques": ["[+1 Gold] from every [Luxury resource]", "[1] Happiness from each type of luxury resource]"],
 		"cities": ["Amsterdam","Rotterdam","Utrecht","Groningen","Breda","Nijimegen","Den Haag","Haarlem","Arnhem","Zutphen",
 			"Maastricht","Tilburg","Eindhoven","Dordrecht","Leiden","Hertogenbosch","Almere","Alkmaar","Brielle","Vlissingen",
 			"Apeldoorn","Nova Enschede","Sao Bernardo do Amersfoort","Zwolle","Venlo","Uden","Grave","Delft","Gouda","Nieuwstadt",
@@ -1530,8 +1524,7 @@
 		"outerColor": [234,0,0],
 		"innerColor": [255,143,0],
 		"uniqueName": "Castle Builders",
-		"uniqueText": "+10% combat strength outside of friendly territory. +5 defensive Strength in every City.",
-		"uniques": ["[+10]% Strength for [Non-City] units fighting in [Foreign Land]","Gain a free [Castle Builders] [in all cities]"],
+		"uniques": ["[+20]% Strength <for [Military] units> <in [Foreign Land] tiles>","Gain a free [Castle Builders] [in all cities]"],
 		"cities": ["Caen","Bayeux","Rouen","Saint-Valery","Le Havre","Cherbourg","Honfleur","Evreux","Coutances","Mayenne","Beauvais","Fecamp","Dreux"]
 	},
 				{
@@ -1575,7 +1568,7 @@
 		"outerColor": [184,179,112],
 		"innerColor": [105,73,45],
 		"uniqueName": "Ta-Seti",
-		"uniques": ["[+1 Production] from every [Flood plains]","Receive free [Apedemaks Bow] when you discover [Pottery]"],
+		"uniques": ["[+1 ProdReceive free [Apedemaks Bow] when you discover [Pottery]"],
 		"cities": ["Meroe","Napata","Kerma","Nuri","Kawa","Sadeinga","Iken","Buhen","Faras","Pademe","Shaat","Heh","Dengeil"]
 	},
 						{
@@ -1597,7 +1590,6 @@
 		"outerColor": [155,44,24],
 		"innerColor": [211,204,27],
 		"uniqueName": "Chain of the Earth",
-		"uniqueText": "All Naval Units ignore Zone of Control movement penalties. Receive a free Seaport in captured Cities",
 		"uniques": ["[Water] units gain the [Chain of the Earth] promotion", "Gain a free [Seaport] [in annexed cities]"],
 		"cities": ["Muscat","Salalah","Nizwa","Sur","Ibra","Bahla","Rustaq","Barka","Muttrah","Sahar","Sahan","Samail","Khasab","Raysut","Jabrin","Al Hamra","Seeb","Duqm"]
 	},
@@ -1664,7 +1656,7 @@
 		"outerColor": [153,5,3],
 		"innerColor": [244,232,54],
 		"uniqueName": "Achaemenid Legacy",
-		"uniques": ["[+50]% Golden Age length","[+1] Movement <for [All] units> <during a Golden Age>","[+10]% Strength <for [All] units> <during a Golden Age>"],
+		"uniques": ["[+50]% Golden Age length","[+1] Movement <for [All] units> <during a Golden Age>"],
 		"cities": ["Persepolis","Parsagadae","Susa","Ecbatana","Tarsus","Gordium","Bactra","Sardis","Ergili","Dariushkabir",
 			"Ghulaman","Zohak","Istakhr","Jinjan","Borazjan","Herat","Dakyanus","Bampur","Turengtepe","Rey","Shiraz",
 			"Thuspa","Hasanlu","Gabae","Merv","Behistun","Kandahar","Altintepe","Bunyan","Charsadda","Uratyube",
@@ -1692,7 +1684,7 @@
 		"outerColor": [177,55,73],
 		"innerColor": [234,201,52],
 		"uniqueName": "Skillful Traders",
-		"uniques": ["Provides [2] [Trade Route (Count)]", "Provides [2] [Trade Route]","Receive free [Square Sail Ship] when you discover [Pottery]"],
+		"uniques": ["Provides [2] [Trade Route (Count)]", "Provides [2] [Trade Route]","Receive free [Square Sail Ship] when you discover [Sailing]"],
 		"cities": ["Tyre","Sidon","Ugarit","Berytus","Byblos","Arvad","Kition","Tripolis","Baalbek","Sarepta","Dor","Orthosias"]
 	},
 	{
@@ -1764,8 +1756,8 @@
 		"outerColor": [206,206,205],
 		"innerColor": [8,25,115],
 		"uniqueName": "Mare Clausum",
-		"uniques": ["[+3 Gold] from every [Luxury resource]","[+25]% Production when constructing [Caravan] units [in all cities]",
-			"[+25]% Production when constructing [Cargo Ship] units [in all cities]"],
+		"uniques": ["[+3 Gold] from every [Luxury resource]","[+33]% Production when constructing [Caravan] units [in all cities]",
+			"[+33]% Production when constructing [Cargo Ship] units [in all cities]"],
 		"cities": ["Lisbon","Porto","Braga","Coimbra","Funchal","Leiria","Goa","Vila Nova de Gaia","Aveiro","Luanda",
 			"Evora","Faro","Castelo Branco","Bissau","Guarda","Viseu","Praia","Braganza","Beja","Tomar",
 			"Maputo","Tavira","Figueira da Foz","Viana do Castelo","São Tomé and Príncipe","Silves","Sintra","Dili","Lamego",
@@ -1811,7 +1803,7 @@
 		"outerColor": [2,51,69],
 		"innerColor": [197,196,72],
 		"uniqueName": "Nihil Sine Deo",
-		"uniques": ["Earn [25]% of killed [Military] unit's [Strength] as [Science]","Earn [25]% of killed [Military] unit's [Strength] as [Culture]"],
+		"uniques": ["[+20]% Strength <for [Military] units> <vs [Wounded] units>", "[+20]% [Culture] [in all cities] <during a Golden Age>"],
 		"cities": ["Bucharest","Craiova","Iasi","Constanta","Botosani","Braila","Ploiesti","Galati","Bacau","Pitesti","Suceava","Buzau","Piatra Neamt"]
 	},
 	{
@@ -1884,8 +1876,7 @@
 		"outerColor": [5,60,77],
 		"innerColor": [201,214,217],
 		"uniqueName": "Flower of Scotland",
-		"uniqueText": "+3 Culture, +3 Science, +3 Production from Grand Temple and Hermitage, +33% faster Great Person generation in the Capital.",
-		"uniques": ["[+3 Culture, +3 Science, +3 Production] from every [Grand Temple]","[+3 Culture, +3 Science, +3 Production] from every [Hermitage]","[+33]% Great Person generation [in capital]",
+		"uniques": ["[+2 Culture, +2 Science, +2 Production] from every [Writer Guild]","[+2 Culture, +2 Science, +2 Production] from every [Artist Guild]","[+2 Culture, +2 Science, +2 Production] from every [Musician Guild]","[+33]% Great Person generation [in capital]",
 		"cities": ["Edinbourgh","Glasgow","Stirling","Aberdeen","Dundee","Inverness","Perth","Dunfermline","Kilmarnock","Dumfries","Lanark","Dumbarton","Falkirk"]
 	},
 	{
@@ -1906,8 +1897,7 @@
 		"outerColor": [65,54,42],
 		"innerColor": [78,244,234],
 		"uniqueName": "Great Expanse",
-		"uniqueText": "Increased rate of border expansion. +15% combat bonus for units fighting in Friendly Land",
-		"uniques": ["[-75]% Culture cost of natural border growth [in this city]","[+15]% combat bonus for [Non-City] units fighting in [Friendly Land]"],
+		"uniques": ["[-75]% Culture cost of natural border growth [in this city]", "[+20]% Strength <for [Military] units> <in [Friendly Land] tiles>"],
 		"cities": ["Moson Kahni","Te-Moak","Agaidika","Goshute","Pohokwi","Washakie","Timbisha","Hukandeka","Duckwater","Tukudeka",
 			"Kuchundeka","Yomba","Kamudeka","Ely","Yambadeka","Nampa","Bannock","Yahandeka","Tetadeka","Deheyaeka",
 			"Pengwideka","Winnemucca","Skull Valley","Big Pine","Duck Valley"]
@@ -1931,7 +1921,7 @@
 		"outerColor": [228,208,43],
 		"innerColor": [193,21,17],
 		"uniqueName": "Father Governs Children",
-		"uniques": ["[+50]% [Culture] from City-States","[+50]% [Food] from City-States","Military Units gifted from City-States start with [+10] XP"],
+		"uniques": ["[+50]% [Culture] from City-States","[+50]% [Food] from City-States","[+50]% [Faith] from City-States","Military Units gifted from City-States start with [+10] XP"],
 		"cities": ["Sukhothai","Si Satchanalai","Muang Saluang","Lampang","Phitsanulok","Kamphaeng Pet","Nakhom Chum","Vientiane",
 			"Nakhon Si Thammarat","Martaban","Nakhon Sawan","Chainat","Luang Prabang","Uttaradit","Chiang Thong","Phrae",
 			"Nan","Tak","Suphanburi","Hongsawadee","Thawaii","Ayutthuya","Taphan Hin","Uthai Thani","Lap Buri","Ratchasima",
@@ -1956,7 +1946,6 @@
 		"outerColor": [214,145,19],
 		"innerColor": [90,0,10],
 		"uniqueName": "River Warlord",
-		"uniqueText": "Receive triple Gold from Barbarian encampments and pillaging Cities. Land units gain the War Canoes and Amphibious promotions",
 		"uniques": ["Receive triple Gold from Barbarian encampments and pillaging Cities","[Land] units gain the [Amphibious] promotion",
 			"[Land] units gain the [War Canoes] promotion"],
 		"cities": ["Gao","Tombouctu","Jenne","Taghaza","Tondibi","Kumbi Saleh","Kukia","Walata","Tegdaoust","Argungu","Gwandu",
@@ -1980,9 +1969,9 @@
 		"hateHello": "What do you want?",
 		"tradeRequest": "Better hurry, I may change my mind.",
 		"outerColor": [255,120,0],
-		"innerColor": [77,32,32],
+		"innerColor": [77,/32,32],
 		"uniqueName": "Dwellers of the Plains",
-		"uniques": ["[+15]% combat bonus for [Non-City] units fighting in [Plains]"],
+		"uniques": ["[+15]% Strength <for [Military] units> <in [Plains] tiles>"],
 		"cities": ["Ihankthunwanna","Bdewekhanthunwan","Isanyathi","Sichangju","Oglala","Itazipcho","Assiniboine","Sisithunwan","Wahpekhute","Wahpethunwan","Hunkpapha","Mnikhowozu","Sihasapa"]
 	},
 	{
@@ -2004,7 +1993,7 @@
 		"outerColor": [102,0,0],
 		"innerColor": [255,102,102],
 		"uniqueName": "Seven Cities of Gold",
-		"uniques": ["100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it)","[+1 Happiness] for every known Natural Wonder", "[+100]% Yield from every [Natural Wonder]"],
+		"uniques": ["[+100 Gold] <upon discovering a Natural Wonder>","[+1 Happiness] for every known Natural Wonder", "[+100]% Yield from every [Natural Wonder]"],
 		"cities": ["Madrid","Barcelona","Seville","Cordoba","Toledo","Santiago","Salamanca","Murcia","Valencia","Zaragoza","Pamplona",
 			"Vitoria","Santander","Oviedo","Jaen","Logroño","Valladolid","Palma","Teruel","Almeria","Leon","Zamora","Mida",
 			"Lugo","Alicante","Càdiz","Eiche","Alcorcon","Burgos","Vigo","Badajoz","La Coruña","Guadalquivir","Bilbao",
@@ -2028,7 +2017,7 @@
 		"outerColor": [16,74,115],
 		"innerColor": [228,111,87],
 		"uniqueName": "Cradle of Civilization",
-		"uniques": ["[+2 Culture] [in all cities] <before discovering [Drama and Poetry]>"],
+		"uniques": ["[+2 Culture] [in all cities] <after discovering [Drama and Poetry]>"],
 		"cities": ["Ur","Kish","Uruk","Eridu","Umma","Lagash","Akshak","Larak","Bad-Tibira","Larsa","Isin","Shruppak","Nibru"]
 	},
 	{
@@ -2097,7 +2086,6 @@
 		"outerColor": [57,57,57],
 		"innerColor": [255,45,45],
 		"uniqueName": "Ulugh Beg's Observatory",
-		"uniqueText": "+10% Production, +10% Science, +10% Culture, +10% Gold and +5 defensive Strength in capital.",
 		"uniques": ["Gain a free [Ulugh Beg's Observatory] [in capital]"],
 		"cities": ["Samarkand","Herat","Balkh","Bukhara","Kabul","Nishapur","Urgench","Merv","Ghazni","Kandahar","Tashkent","Tabriz","Tiflis"]
 	},
@@ -2142,7 +2130,6 @@
 		"outerColor": [255,227,151],
 		"innerColor": [191,24,38],
 		"uniqueName": "Westernization",
-		"uniqueText": "+50% Production when constructing Amphitheaters, Opera Houses, Museums and Broadcast Towers. All of these Buildings provide +1 Science and +1 Production.",
 		"uniques": ["[+1 Production, +1 Science] from every [Amphitheater]","[+1 Production, +1 Science] from every [Museum]","[+1 Production, +1 Science] from every [Opera House]","[+1 Production, +1 Science] from every [Broadcast Tower]",
 			"[+50]% Production when constructing [Amphitheater] buildings [in all cities]",
 			"[+50]% Production when constructing [Opera House] buildings [in all cities]",
@@ -2168,7 +2155,6 @@
 		"outerColor": [21,34,78],
 		"innerColor": [255,233,142],
 		"uniqueName": "The Way of Chumaks",
-		"uniqueText": "+1 Food from Maize, Wheat and Salt resources after researching The Wheel, +2 Gold from each city connected to capital",
 		"uniques": ["[+1 Food] from every [Maize] <after discovering [The Wheel]>","[+1 Food] from every [Wheat] <after discovering [The Wheel]>","[+1 Food] from every [Salt] <after discovering [The Wheel]>", "[+2 Gold] from each Trade Route"]
 		"cities": ["Kiev","Kharkiv","Zaporizhia","Odessa","Dnipropetrovsk","Donetsk","Luhansk","Zhytomyr","Lviv","Kryvyi Rih","Chernihiv","Mariupol","Mykolaiv"]
 	},
@@ -2191,9 +2177,7 @@
 		"outerColor": [105,34,172],
 		"innerColor": [255,254,231],
 		"uniqueName": "Serenissima",
-		"uniqueText": "Cannot gain settlers, Double the normal number of trade routes available, Receive free Merchant of Venice when you discover Optics",
-		"uniques": ["[+100]% [Gold] [in capital]","Receive free [Merchant of Venice] when you discover [Optics]",
-			"Double quantity of [Trade Route] produced","Double quantity of [Trade Route (Count)] produced"],
+		"uniques": ["Provides [1] [Trade Route (Count)] <upon discovering [Compass]>","Provides [1] [Trade Route] <upon discovering [Compass]>", "Free [Cargo Ship] appears <upon discovering [Compass]>"],
 		"cities": ["Venice","Ragusa","Candia","Zara","Durazzo","Tessalonica","Limassol","Patras","Nicosia","Spalato","Veroz","Ravenna","Negroponte","Athens","Burano","Leonessa","Cerigo"]
 		
 	},
@@ -2260,7 +2244,6 @@
 		"outerColor": [70,70,82],
 		"innerColor": [205,146,68],
 		"uniqueName": "Great Zimbabwe",
-		"uniqueText": "+25% Production when constructing buildings and military units in capital.",
 		"uniques": ["[+25]% Production when constructing [All] buildings [in capital]","[+25]% Production when constructing [Military] units [in in capital]"],
 		"cities": ["Great Zimbabwe","Khami","Zvongombe","Danamombe","MApangubwe","Mayenne","Harare","Bulawayo","Chitungwiza","Mutare","Epworth","Gweru","Kwekwe","Kadoma"]
 	},

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -415,7 +415,7 @@
 			},
 			{
 				"name": "Entrepreneurship",
-				"uniques": ["[-50]% maintenance on road & railroads","Provides 2 Trade Routes"],
+				"uniques": ["[-50]% maintenance on road & railroads","Provides [2] [Trade Route (Count)]","Provides [2] [Trade Route]"],
 				"requires": ["Silk Road"],
 				"row": 2,
 				"column": 1

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -110,8 +110,7 @@
 	{
 		"name": "Honor",
 		"era": "Ancient era",
-		"uniques": ["[+33]% Strength <vs [Barbarian] units>","Earn [33]% of killed [Military] unit's [Strength] as [Culture]",
-			"Notified of new Barbarian encampments","Unlocks building the Temple of Artemis"],
+		"uniques": ["[+33]% Strength <vs [Barbarian] units>", "Earn [33]% of killed [Military] unit's [Strength] as [Culture]", "Unlocks building the Temple of Artemis"],
 		"policies": [
 			{
 				"name": "Warrior Code",
@@ -165,37 +164,36 @@
 		"era": "Ancient era",
 		"uniques": ["[+100]% Production when constructing [Temple] buildings [in all cities]",
 			"[+100]% Production when constructing [Shrine] buildings [in all cities]",
-			"[+2 Culture] [in capital]","Unlocks building the Great Mosque of Djenne"],
+			"[+1 Culture, +1 Faith] [in capital]","Unlocks building the Great Mosque of Djenne"],
 		"policies": [
 			{
 				"name": "Mandate Of Heaven",
-				"uniques": ["[+1 Happiness] from every [Temple]","[+1 Culture] [in capital]","Cost of purchasing [Culture] buildings reduced by [20]%"],
+				"uniques": ["[+1 Happiness] from every [Temple]","[+1 Faith] [in capital]","Cost of purchasing [Faith] buildings reduced by [20]%"],
 				"row": 1,
 				"column": 1
 			},
 			{
 				"name": "Organized Religion",
-				"uniques": ["[+1 Culture] from every [Shrine]","[+1 Culture] from every [Temple]",
-					"[+1 Culture] from every [Monastery]"],
+				"uniques": ["[+1 Culture, +1 Faith] from every [Shrine]","[+1 Culture, +1 Faith] from every [Temple]"],
 				"row": 1,
 				"column": 3
 			},
 			{
 				"name": "Theocracy",
-				"uniques": ["[+33]% [Gold] from every [Grand Temple]","[+2 Gold] from every [Temple]","[+3 Gold] from every [Holy site]"],
+				"uniques": ["[+33]% [Gold] from every [Grand Temple]","[+1 Gold] from every [Temple]","[+1 Gold] from every [Shrine]","[+3 Gold] from every [Holy site]"],
 				"row": 1,
 				"column": 5
 			},
 			{
 				"name": "Reformation",
-				"uniques": ["[-15]% Culture cost of natural border growth [in all cities]"],
+				"uniques": ["[-15]% Culture cost of natural border growth [in all cities]","May choose [1] additional belief(s) of any type when [enhancing] a religion"],
 				"requires": ["Organized Religion"],
 				"row": 2,
 				"column": 2
 			},
 			{
 				"name": "Religious Tolerance",
-				"uniques": ["[+1 Culture] [in all cities]","[+25]% [Science] from every [Grand Temple]","[+2 Science] from every [Temple]"],
+				"uniques": ["[+1 Culture, +1 Faith] [in all cities]","[+25]% [Science] from every [Grand Temple]","[+2 Science] from every [Temple]"],
 				"requires": ["Organized Religion"],
 				"row": 2,
 				"column": 4
@@ -261,8 +259,7 @@
 		"policies": [
 			{
 				"name": "Merchant Confederacy",
-				"uniques": ["[+2 Gold] from every [Land Trade Route (Food)]","[+2 Gold] from every [Land Trade Route (Production)]",
-					"[+2 Gold] from every [Land Trade Route (Gold)]","[+2 Gold] from every [Sea Trade Route (Food)]",
+				"uniques": ["[+2 Gold, +2 Production, +2 Food] from every [Land Trade Route (Gold)]","[+2 Gold, +2 Production, +2 Food] from every [Sea Trade Route (Food)]",
 					"[+2 Gold] from every [Sea Trade Route (Production)]","[+2 Gold] from every [Sea Trade Route (Gold)]"],
 				"row": 1,
 				"column": 3
@@ -276,7 +273,7 @@
 			},
 			{
 				"name": "Cultural Diplomacy",
-				"uniques":["[+100]% resources gifted by City-States"],
+				"uniques":["[+100]% resources gifted by City-States","[+50]% [Happiness] from City-States"],
 				"requires": ["Merchant Confederacy"],
 				"row": 2,
 				"column": 3
@@ -298,7 +295,7 @@
 
 			{
 				"name": "Patronage Complete",
-				"uniques": ["Food and Culture from Friendly City-States are increased by 50%","Free Great Person"],
+				"uniques": ["[+75]% [Culture] from City-States","[+75]% [Faith] from City-States","[+75]% [Food] from City-States","Free Great Person"],
 			}
 		]
 	},
@@ -325,7 +322,7 @@
 			},
 			{
 				"name": "Colonialism",
-				"uniques": ["+1 population in each city","[+1 Happiness] [in all cities]","Free [Worker] appears"],
+				"uniques": [ "[1] population [in all cities]","[+1 Happiness] [in all cities]","Free [Worker] appears"],
 				"row": 1,
 				"column": 5
 			},
@@ -338,7 +335,7 @@
 			},
 			{
 				"name": "Treasure Fleets",
-				"uniques": ["[+1 Gold] from every [Coast]","[+1 Production] from every [Coast]","[+1 Food] from every [Coast]","[+1 Gold] from every [Ocean]","[+1 Production] from every [Ocean]","[+1 Food] from every [Ocean]"],
+				"uniques": ["[+1 Gold, +1 Production, +1 Food] from every [Coast]","[+1 Gold, +1 Production, +1 Food] from every [Ocean]"],
 				"requires": ["Navigation School"],
 				"row": 3,
 				"column": 3
@@ -392,7 +389,7 @@
 			},
 			{
 				"name": "Rationalism Complete",
-				"uniques": ["[10]% [Science] <while the empire is happy>","May buy [Great Scientist] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"]
+				"uniques": ["[10]% [Science] <while the empire is happy>"]
 			}
 		]
 	},
@@ -415,7 +412,7 @@
 			},
 			{
 				"name": "Entrepreneurship",
-				"uniques": ["[-50]% maintenance on road & railroads","Provides [2] [Trade Route (Count)]","Provides [2] [Trade Route]"],
+				"uniques": ["[-50]% maintenance on road & railroads","[-25]% maintenance cost for buildings [in all cities]","Provides [2] [Trade Route (Count)]","Provides [2] [Trade Route]"],
 				"requires": ["Silk Road"],
 				"row": 2,
 				"column": 1
@@ -430,7 +427,7 @@
 			},
 			{
 				"name": "Protectionism",
-				"uniques": ["[+1 Food] from every [Customs house]","[+4 Gold] from every [Customs house]","[+4 Production, +4 Culture, +4 Happiness] from every [East India Company]",],
+				"uniques": ["[+1 Food, +4 Gold] from every [Customs house]","[+4 Production, +4 Culture, +4 Happiness] from every [East India Company]",],
 				"requires": ["Mercantilism"],
 				"row": 3,
 				"column": 3
@@ -501,15 +498,14 @@
 			{
 				"name": "Skyscrapers",
 				"uniqueText": "Cost of purchasing buildings reduced by [50]%",
-				"uniques": ["Cost of purchasing [Science] buildings reduced by [50]%","Cost of purchasing [Production] buildings reduced by [50]%","Cost of purchasing [Food] buildings reduced by [50]%","Cost of purchasing [Gold] buildings reduced by [50]%","Cost of purchasing [Happiness] buildings reduced by [50]%","Cost of purchasing [Culture] buildings reduced by [50]%"],
+				"uniques": ["[Gold] cost of purchasing [All] buildings [-50]%"],
 				"requires": ["Young Pioneers"],
 				"row": 2,
 				"column": 1
 			},
 			{
 				"name": "Party Leadership",
-				"uniques": ["[+2 Food] [in all cities]","[+2 Production] [in all cities]","[+2 Science] [in all cities]",
-					"[+2 Gold] [in all cities]"],
+				"uniques": ["[+2 Food, +2 Gold, +2 Production, +2 Science] [in all cities]"],
 				"requires": ["Young Pioneers"],
 				"row": 2,
 				"column": 3
@@ -542,7 +538,7 @@
 		"policies": [
 			{
 				"name": "Avant Garde",
-				"uniques": ["[+20]% great person generation in all cities"],
+				"uniques": ["[+25]% great person generation in all cities"],
 				"row": 1,
 				"column": 1
 			},
@@ -554,7 +550,7 @@
 			},
 			{
 				"name": "Free Healthcare",
-				"uniques": ["[+1 Happiness] from every [East India Company]","[+1 Happiness] from every [National Visitor's Center]","[+1 Happiness] from every [Oxford University]","[+1 Happiness] from every [Hermitage]","[+1 Happiness] from every [Ironworks]","[+1 Happiness] from every [Grand Temple]","[+1 Happiness] from every [National Epic]","[+1 Happiness] from every [National College]","[+1 Happiness] from every [Heroic Epic]","[+1 Happiness] from every [Circus Maximus]"],
+				"uniques": ["[+1 Happiness] from every [National Wonder]"],
 				"row": 1,
 				"column": 5
 			},
@@ -599,13 +595,13 @@
 			},
 			{
 				"name": "New Deal",
-				"uniques": ["[+100]% Yield from every [Great Improvement]"],
+				"uniques": ["[+5 Science] from every [Academy]","[+5 Production] from every [Manufactory]","[+5 Faith] from every [Holy site]","[+5 Culture] from every [Landmark]","[+5 Gold] from every [Customs house]", "[+1 Culture, +1 Science, +1 Faith, +1 Production, +1 Food] from every [Sacred Grove]"],
 				"requires": ["Capitalism"],
 				"row": 2,
 				"column": 3
 			},
 			{
-				"name": "Democracy",
+				"name": "Treaty Organization",
 				"uniques": ["[+1 Production] from every specialist [in all cities]"],
 				"requires": ["Capitalism"],
 				"row": 2,
@@ -614,7 +610,7 @@
 			{
 				"name": "Media Culture",
 				"uniques": ["[+33]% [Culture] from every [Broadcast Tower]"],
-				"requires": ["Democracy","New Deal","Urbanization"],
+				"requires": ["Treaty Organization","New Deal","Urbanization"],
 				"row": 3,
 				"column": 3
 			},
@@ -631,7 +627,7 @@
 		"policies": [
 			{
 				"name": "Elite Forces",
-				"uniques": ["[+10]% Strength <for [Military] units> <when attacking>","[+10]% Strength <for [Military] units> <when defending>"],
+				"uniques": ["[+10]% Strength <for [Military] units>", "[+10] HP when healing <for [Military] units>"],
 				"row": 1,
 				"column": 1
 			},
@@ -675,7 +671,7 @@
 		"policies": [
 			{
 				"name": "Universal Healthcare",
-				"uniques": ["[+1 Happiness] from every [East India Company]","[+1 Happiness] from every [National Visitor's Center]","[+1 Happiness] from every [Oxford University]","[+1 Happiness] from every [Hermitage]","[+1 Happiness] from every [Ironworks]","[+1 Happiness] from every [Grand Temple]","[+1 Happiness] from every [National Epic]","[+1 Happiness] from every [National College]","[+1 Happiness] from every [Heroic Epic]","[+1 Happiness] from every [Circus Maximus]"],
+				"uniques": ["[+1 Happiness] from every [National Wonder]"],
 				"requires": ["Autocracy Complete"],
 				"row": 1,
 				"column": 3
@@ -691,7 +687,7 @@
 				"name": "Third Alternative",
 				"uniques": ["Double quantity of [Horses] produced","Double quantity of [Iron] produced",
 					"Double quantity of [Coal] produced","Double quantity of [Oil] produced",
-					"Double quantity of [Aluminum] produced","Double quantity of [Uranium] produced","[+5 Science] [in capital]","[+5 Food] [in capital]"],
+					"Double quantity of [Aluminum] produced","Double quantity of [Uranium] produced","[+5 Science, +5 Food] [in capital]"],
 				"requires": ["Universal Healthcare"],				
 				"row": 2,
 				"column": 3
@@ -705,7 +701,7 @@
 			},
 			{
 				"name": "Clausewitz's Legacy",
-				"uniques": ["[+25]% Strength <when attacking> <for [Military] units> <for [50] turns>"],
+				"uniques": ["[+25]% Strength <for [Military] units> <for [50] turns>"],
 				"requires": ["Nationalism","Third Alternative","Militarism"],				
 				"row": 3,
 				"column": 3

--- a/jsons/Ruins.json
+++ b/jsons/Ruins.json
@@ -1,8 +1,8 @@
 [
     {
         "name": "freeCulture",
-        "notification": "We have discovered cultural artifacts in the ruins! (+20 culture)",
-        "uniques": ["Gain [20] [Culture]"]
+        "notification": "We have discovered cultural artifacts in the ruins! (+10 culture)",
+        "uniques": ["Gain [15] [Culture] <after 10 turns>"]
     },
     {
         "name": "joinWorker",
@@ -15,11 +15,6 @@
         "notification": "A [Settler] has joined us!",
         "uniques": ["Free [Settler] found in the ruins"],
         "excludedDifficulties": ["Warlord","Prince","King","Emperor","Immortal","Deity"]
-    },
-    {
-        "name": "freeXP",
-        "notification": "An ancient tribe trained us in their ways of combat!",
-        "uniques": ["This Unit gains [10] XP"]
     },
     {
         "name": "freePop",
@@ -42,23 +37,13 @@
         "uniques": ["This Unit upgrades for free including special upgrades"]
     },
     {
-        "name": "barbCampsRevealed",
-        "notification": "You find evidence of Barbarian activity. Nearby Barbarian camps are revealed!",
-        "uniques": ["Reveal up to [All] [Barbarian encampment] within a [10] tile radius"]
-    },
-    {
         "name": "crudelyDrawnMap",
         "notification": "We have found a crudely-drawn map in the ruins!",
-        "uniques": ["From a randomly chosen tile [4] tiles away, reveal tiles up to [4] tiles away with [80]% chance"]
+        "uniques": ["Reveal up to [All] [All] within a [6] tile radius"]
     },
     {
         "name": "holySymbols",
         "notification": "We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith)",
-        "uniques": ["Hidden when religion is disabled", "Gain enough Faith for a Pantheon"]
+        "uniques": ["Hidden when religion is disabled", "Gain [20] [Faith] <after [10] turns>"]
     },
-    {
-        "name": "prophecy",
-        "notification": "We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith)",
-        "uniques": ["Hidden when religion is disabled", "Gain enough Faith for [33]% of a Great Prophet", "Hidden after generating a Great Prophet"]
-    }
 ]

--- a/jsons/Ruins.json
+++ b/jsons/Ruins.json
@@ -2,7 +2,7 @@
     {
         "name": "freeCulture",
         "notification": "We have discovered cultural artifacts in the ruins! (+10 culture)",
-        "uniques": ["Gain [15] [Culture] <after 10 turns>"]
+        "uniques": ["Gain [15] [Culture] <after [10] turns>"]
     },
     {
         "name": "joinWorker",

--- a/jsons/Techs.json
+++ b/jsons/Techs.json
@@ -9,7 +9,7 @@
 				"name": "Agriculture",
 				"row": 5,
 				"quote": "'Where tillage begins, other arts follow. The farmers therefore are the founders of human civilization.' - Daniel Webster",
-				"uniques": ["Starting tech","Enables Open Borders agreements"]
+				"uniques": ["Starting tech","Enables Open Borders agreements", "Notified of new Barbarian encampments", "[+1 Food] [in all cities] <in tiles without [Hill]>"]
 			}
 		]	
 	},

--- a/jsons/Techs.json
+++ b/jsons/Techs.json
@@ -30,6 +30,7 @@
 				"row": 5,
 				"prerequisites": ["Agriculture"],
 				"quote": "'Thou shalt not muzzle the ox when he treadeth out the corn.' - Bible Deuteronomy 25:4"
+				"uniques": ["Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]"],
 			},
 			{
 				"name": "Archery",
@@ -58,6 +59,7 @@
 				"row": 1,
 				"prerequisites": ["Pottery"],
 				"quote": "'He who commands the sea has command of everything.' - Themistocles"
+				"uniques": ["Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]"],
 			},
 			{
 				"name": "Calendar",
@@ -163,6 +165,7 @@
 				"prerequisites": ["Mathematics","Construction"],
 				"uniques": ["Roads connect tiles across rivers"],
 				"quote": "'Instrumental or mechanical science is the noblest and, above all others, the most useful.' - Leonardo da Vinci"
+				"uniques": ["Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]"],
 			},
 			{
 				"name": "Iron Working",
@@ -219,6 +222,7 @@
 				"row": 1,
 				"prerequisites": ["Optics","Theology"],
 				"quote": "'I find the great thing in this world is not so much where we stand, as in what direction we are moving.' - Oliver Wendell Holmes"
+				"uniques": ["Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]"],
 			},
 			{
 				"name": "Education",
@@ -279,6 +283,7 @@
 				"row": 6,
 				"prerequisites": ["Chivalry","Education"],
 				"quote": "'Happiness: a good bank account, a good cook and a good digestion' - Jean Jacques Rousseau"
+				"uniques": ["Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]"],
 			},
 			{
 				"name": "Printing Press",
@@ -390,6 +395,7 @@
 				"row": 2,
 				"prerequisites": ["Archaeology","Scientific Theory"],
 				"quote": "'If the brain were so simple we could understand it, we would be so simple we couldn't.' - Lyall Watson"
+				"uniques": ["Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]"],
 			},
 			{
 				"name": "Electricity",
@@ -448,6 +454,7 @@
 				"row": 8,
 				"prerequisites": ["Steam Power","Dynamite"],
 				"quote": "'The introduction of so powerful an agent as steam to a carriage on wheels will make a great change in the situation of man.' - Thomas Jefferson"
+				"uniques": ["Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]"],
 			}
 		]	
 	},
@@ -496,6 +503,7 @@
 				"row": 2,
 				"prerequisites": ["Plastics","Refrigeration"],
 				"quote": "'In nothing do men more nearly approach the gods than in giving health to men.' - Cicero"
+				"uniques": ["Provides [1] [Trade Route (Count)]","Provides [1] [Trade Route]"],
 			},
 			{
 				"name": "Atomic Theory",

--- a/jsons/Terrains.json
+++ b/jsons/Terrains.json
@@ -21,7 +21,6 @@
  "type": "Land",
  "food": 2,
  "movementCost": 1,
- "defenceBonus": -0.1,
  "RGB": [97,171,58],
  "uniques":
   ["Occurs at temperature between [-0.4] and [0.1] and humidity between [0.2] and [0.4]",
@@ -47,7 +46,6 @@
  "type": "Land",
  "food": 1, "production": 1,
  "movementCost": 1,
- "defenceBonus": -0.1,
  "RGB": [168,185,102],
  "uniques":
   ["Occurs at temperature between [-0.4] and [-0.1] and humidity between [0] and [0.2]",
@@ -76,7 +74,6 @@
  "type": "Land",
  "food": 1,
  "movementCost": 1,
- "defenceBonus": -0.1,
  "RGB": [189,204,191],
  "uniques":
   ["Occurs at temperature between [-0.9] and [-0.6] and humidity between [0.8] and [1]",
@@ -94,7 +91,6 @@
 {"name": "Desert",
  "type": "Land",
  "movementCost": 1,
- "defenceBonus": -0.1,
  "RGB": [ 230, 230, 113],
  "uniques":
   ["Occurs at temperature between [-0.1] and [0.9] and humidity between [0] and [0.2]",
@@ -111,7 +107,6 @@
 {"name": "Snow",
  "type": "Land",
  "movementCost": 1,
- "defenceBonus": -0.1,
  "RGB": [231, 242, 249],
  "uniques":
   ["Occurs at temperature between [-1] and [-0.9] and humidity between [0] and [1]",

--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -93,40 +93,38 @@
 	{
 		"name": "Land Trade Route (Food)",
 		"terrainsCanBeBuiltOn": ["Plains","Grassland","Desert","Hill","Tundra","Forest","Jungle","Flood plains","Marsh","Oasis"],
-		"food": 1,
-		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]"]
+		"food": 3,
+		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]","[+1 Food] <starting from the [Classical era]>", "[+1 Food] <starting from the [Industrial era]>", "[+1 Food] <starting from the [Modern era]>"]
 	},
 	{
 		"name": "Land Trade Route (Production)",
 		"terrainsCanBeBuiltOn": ["Plains","Grassland","Desert","Hill","Tundra","Forest","Jungle","Flood plains","Marsh","Oasis"],
-		"production": 1,
-		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]"]
+		"production": 3,
+		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]","[+1 Production] <starting from the [Classical era]>", "[+1 Production] <starting from the [Industrial era]>", "[+1 Production] <starting from the [Modern era]>"]
 	},
 	{
 		"name": "Land Trade Route (Gold)",
 		"terrainsCanBeBuiltOn": ["Plains","Grassland","Desert","Hill","Tundra","Forest","Jungle","Flood plains","Marsh","Oasis"],
-		"gold": 2,
-		"science": 2,
-		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]"]
+		"gold": 3,
+		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]","[+1 Gold] <starting from the [Classical era]>", "[+1 Gold] <starting from the [Industrial era]>", "[+1 Gold] <starting from the [Modern era]>"]
 	},
 	{
 		"name": "Sea Trade Route (Food)",
 		"terrainsCanBeBuiltOn": ["Coast","Ocean","Atoll"],
-		"food": 2,
-		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]"]
+		"food": 6,
+		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]","[+2 Food] <starting from the [Classical era]>", "[+2 Food] <starting from the [Industrial era]>", "[+2 Food] <starting from the [Modern era]>"]
 	},
 	{
 		"name": "Sea Trade Route (Production)",
 		"terrainsCanBeBuiltOn": ["Coast","Ocean","Atoll"],
-		"production": 2,
-		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]"]
+		"production": 6,
+		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]","[+2 Production] <starting from the [Classical era]>", "[+2 Production] <starting from the [Industrial era]>", "[+2 Production] <starting from the [Modern era]>"]
 	},
 	{
 		"name": "Sea Trade Route (Gold)",
 		"terrainsCanBeBuiltOn": ["Coast","Ocean","Atoll"],
-		"gold": 4,
-		"science": 2,
-		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]"]
+		"gold": 6,
+		"uniques": ["Provides [-1] [Trade Route]","Provides [-1] [Trade Route (Count)]","[+2 Gold] <starting from the [Classical era]>", "[+2 Gold] <starting from the [Industrial era]>", "[+2 Gold] <starting from the [Modern era]>"]
 	},
 
 	// Military improvements

--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -247,7 +247,7 @@
 	{
 		"name": "Citadel",
 		"terrainsCanBeBuiltOn": ["Land"],
-		"uniques": ["Gives a defensive bonus of [100]%","Adjacent units ending their turn take [30] damage","Great Improvement",
+		"uniques": ["Gives a defensive bonus of [100]%","Adjacent enemy units ending their turn take [30] damage","Great Improvement",
 			"Can be built just outside your borders","Constructing it will take over the tiles around it and assign them to your closest city","Removes removable features when built"],
 			"civilopediaText": [{text:"Constructing it will take over the tiles around it and assign them to your closest city"}]
 	},
@@ -256,7 +256,7 @@
 	{
 		"name": "Moai",
 		"uniqueTo": "Polynesia",
-		"terrainsCanBeBuiltOn": ["Grassland","Plains","Tundra","Desert","Snow"],
+		"terrainsCanBeBuiltOn": ["Land"],
 		"culture": 1,
 		"turnsToBuild": 4,
 		"uniques": ["[+1 Culture] for each adjacent [Moai]","[+1 Gold] <after discovering [Flight]>",
@@ -272,13 +272,14 @@
 		"food": 1,
 		"production": 1,
 		"culture": 1,
-		"uniques": ["Great Improvement","Removes removable features when built","[+1 Science, +1 Production, +1 Culture, +1 Food] <after discovering [Telecommunications]>",
-			"[+1 Science, +1 Production, +1 Culture, +1 Food] <after discovering [Computers]>",
-			"[+1 Science, +1 Production, +1 Culture, +1 Food] <after discovering [Plastics]>",
-			"[+1 Science, +1 Production, +1 Culture, +1 Food] <after discovering [Archaeology]>",
-			"[+1 Science, +1 Production, +1 Culture, +1 Food] <after discovering [Acoustics]>",
-			"[+1 Science, +1 Production, +1 Culture, +1 Food] <after discovering [Theology]>",
-			"[+1 Science, +1 Production, +1 Culture, +1 Food] <after discovering [Philosophy]>"]
+		"faith": 1,
+		"uniques": ["Great Improvement","Removes removable features when built","[+1 Science, +1 Production, +1 Culture, +1 Food, +1 Faith] <after discovering [Telecommunications]>",
+			"[+1 Science, +1 Production, +1 Culture, +1 Food, +1 Faith] <after discovering [Computers]>",
+			"[+1 Science, +1 Production, +1 Culture, +1 Food, +1 Faith] <after discovering [Plastics]>",
+			"[+1 Science, +1 Production, +1 Culture, +1 Food, +1 Faith] <after discovering [Archaeology]>",
+			"[+1 Science, +1 Production, +1 Culture, +1 Food, +1 Faith] <after discovering [Acoustics]>",
+			"[+1 Science, +1 Production, +1 Culture, +1 Food, +1 Faith] <after discovering [Theology]>",
+			"[+1 Science, +1 Production, +1 Culture, +1 Food, +1 Faith] <after discovering [Philosophy]>"]
 	},
 	{
 		"name": "Chateau",
@@ -289,18 +290,18 @@
 		"science": 2,
 		"turnsToBuild":7,
 		"techRequired": "Chivalry",
-		"uniques": ["Gives a defensive bonus of [50]%","[+2 Gold, +1 Culture] <after discovering [Flight]>"]
+		"uniques": ["Gives a defensive bonus of [50]%","[+2 Gold, +1 Culture] <after discovering [Flight]>","Must be next to [Luxury resource]","Cannot be built on [Strategic resource] tiles","Cannot be built on [Luxury resource] tiles","Cannot be built on [Bonus resource] tiles","Only available <with [0] to [0] neighboring [Chateau] tiles>"]
 	},
 		{
 		"name": "Harjis",
 		"uniqueTo": "Goths",
-		"terrainsCanBeBuiltOn": ["Hill"],
+		"terrainsCanBeBuiltOn": ["Land"],
 		"production": 1,
 		"turnsToBuild":7,
 		"techRequired": "Mining",
 		"uniques": ["[+1 Production] <after discovering [Iron Working]>",
 			"[+1 Production] <after discovering [Gunpowder]>",
-			"[+1 Production] <after discovering [Dynamite]>"]
+			"[+1 Production] <after discovering [Dynamite]>","Must be next to [Luxury resource]","Cannot be built on [Luxury resource] tiles","Only available <with [0] to [0] neighboring [Harjis] tiles>"]
 	},
 	{
 		"name": "Brazilwood Camp",
@@ -320,7 +321,7 @@
 		"faith": 2,
 		"turnsToBuild": 7,
 		"techRequired": "Calendar",
-		"uniques": ["[+1 Faith] <after discovering [Theology]>","[+1 Culture] for each adjacent [Mountain]"]
+		"uniques": ["[+1 Faith] <after discovering [Theology]>","[+1 Culture] for each adjacent [Mountain]", "Does not need removal of [Forest]", "Does not need removal of [Jungle]"]
 	},
 	{
 		"name": "Polder",
@@ -339,8 +340,8 @@
 		"faith": 1,
 		"turnsToBuild": 7,
 		"techRequired": "Guilds",
-		"uniques": ["[+1 Food, +1 Gold] <after discovering [Civil Service]>",
-			"[+1 Faith] <after discovering [Theology]>"]
+		"uniques": ["Must be next to [Luxury resource]","[+1 Food] <after discovering [Civil Service]>",
+			"[+1 Faith] <after discovering [Theology]>","[+1 Culture] for each adjacent [City center]","[+1 Gold] <in [River] tiles>"],
 	},
 	{
 		"name": "Kasbah",
@@ -372,17 +373,7 @@
 		"production": 1,
 		"turnsToBuild": 7,
 		"techRequired": "Engineering",
-		"uniques": ["Gives a defensive bonus of [25]%","[+2 Culture] <after discovering [Flight]>"]
-	},
-	{
-		"name": "Feitoria",
-		"uniqueTo": "Portugal",
-		"terrainsCanBeBuiltOn": ["Land"],
-		"turnsToBuild": 7,
-		"gold": 3,
-		"happiness": 2,
-		"techRequired": "Navigation",
-		"uniques": ["Gives a defensive bonus of [50]%","Can only be built on [Coastal] tiles"]
+		"uniques": ["Gives a defensive bonus of [25]%","[+2 Culture] <after discovering [Flight]>","Only available <with [0] to [0] neighboring [Motte and Bailey] tiles>"]
 	},
 		{
 		"name": "Kampong Ayer",
@@ -392,7 +383,7 @@
 		"gold": 1,
 		"culture": 1,
 		"techRequired": "Optics",
-		"uniques": ["[+1 Production] <after discovering [Astronomy]>",
+		"uniques": ["[+1 Production] <after discovering [Navigation]>",
 			"[+1 Culture] <after discovering [Flight]>"]
 	},
 	{

--- a/jsons/TileResources.json
+++ b/jsons/TileResources.json
@@ -129,7 +129,7 @@
 
 {"name": "Iron",
  "resourceType": "Strategic",
- "revealedBy": "Iron Working",
+ "revealedBy": "Mining",
 "terrainsCanBeFoundOn": ["Grassland","Plains","Desert","Tundra","Snow","Hill","Marsh"],
  "production": 1,
  "improvement": "Mine",
@@ -160,7 +160,8 @@
  "improvement": "Mine",
  "improvementStats": {"production": 2},
  "uniques":
-  ["Generated with weight [35] <in [Hill] tiles>",
+  ["Guaranteed with Strategic Balance resource option",
+    "Generated with weight [35] <in [Hill] tiles>",
    "Generated with weight [30] <in [Jungle] tiles> <in tiles without [Hill]>",
    "Generated with weight [30] <in [Forest] tiles> <in tiles without [Hill]>",
    "Minor deposits generated with weight [10] <in [Marsh] tiles> <in tiles without [Hill]>",
@@ -182,7 +183,8 @@
  "improvement": "Oil well",
  "improvementStats": {"production": 3},
  "uniques":
-  ["Deposits in [Coast] tiles always provide [4] resources",
+  [
+    "Deposits in [Coast] tiles always provide [4] resources",
    "Guaranteed with Strategic Balance resource option",
    "Generated with weight [65] <in [Marsh] tiles> <in tiles without [Hill]>",
    "Generated with weight [40] <in [Featureless] [Tundra] tiles>",
@@ -205,7 +207,8 @@
  "improvement": "Mine",
  "improvementStats": {"production": 2},
  "uniques":
-  ["Generated with weight [15] <in [Featureless] [Tundra] tiles>",
+  ["Guaranteed with Strategic Balance resource option",
+    "Generated with weight [15] <in [Featureless] [Tundra] tiles>",
    "Generated with weight [15] <in [Featureless] [Snow] tiles>",
    "Generated with weight [39] <in [Hill] tiles>",
    "Minor deposits generated with weight [20] <in [Jungle] tiles>",
@@ -221,7 +224,8 @@
  "improvement": "Mine",
  "improvementStats": {"production": 2},
  "uniques":
-  ["Generated with weight [35] <in [Marsh] tiles> <in tiles without [Hill]>",
+  ["Guaranteed with Strategic Balance resource option",
+    "Generated with weight [35] <in [Marsh] tiles> <in tiles without [Hill]>",
    "Generated with weight [70] <in [Jungle] tiles> <in tiles without [Hill]>",
    "Generated with weight [70] <in [Forest] tiles> <in tiles without [Hill]>",
    "Minor deposits generated with weight [10] <in [Forest] tiles>",

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -616,13 +616,9 @@
 		"prerequisites": ["Buffalo Chest II"],
 		"unitTypes": ["Melee","Gunpowder"]
 	},
-		{
-		"name": "Epic of Battle",
-		"uniques": ["[+15]% Strength <vs cities>"],
-	},
 	{
 	"name": "Sauna",
-	"uniques": ["+10 HP when healing"],
+	"uniques": ["+10 HP when healing <in Friendly Land tiles>"],
 	},
 		{
 	"name": "Ski Infantry",
@@ -635,70 +631,70 @@
 	},
 	{
 	"name": "Drauhtinon",
-	"uniques": ["[+1] Movement","Heals [25] damage if it kills a unit"]
+	"uniques": ["[+1] Movement"]
 	},
-		{
+	{
 		"name": "Sampy",
 		"uniques": ["Access to special promotions"]
 	},
-		{
+	{
 		"name": "Kelimazala",
 		"uniques": ["[1] additional attacks per turn"],
 		"prerequisites": ["Sampy"],
 		"unitTypes": ["Ranged", "Mounted Ranged"]
 	},
-			{
+	{
 		"name": "Ramahavaly",
 		"uniques": ["[+50]% Strength <when defending>","[-50]% Strength <when attacking>"],
 		"prerequisites": ["Sampy"],
 		"unitTypes": ["Ranged", "Mounted Ranged"]
 	},
-				{
+	{
 		"name": "Manjakatsiroa",
 		"uniques": ["[+25]% Strength <when fighting in [Friendly Land] tiles>"]
 		"prerequisites": ["Sampy"],
 		"unitTypes": ["Ranged", "Mounted Ranged"]
 	},
-					{
+	{
 		"name": "Mosasa",
 		"uniques": ["[+4] Sight","[+4] Range"]
 		"prerequisites": ["Sampy"],
 		"unitTypes": ["Ranged", "Mounted Ranged"]
 	},
-					{
+	{
 		"name": "Ambohimanambola",
 		"uniques": ["[+15]% Strength bonus for [Military] units within [2] tiles"]
 		"prerequisites": ["Sampy"],
 		"unitTypes": ["Ranged", "Mounted Ranged"]
 	},
-						{
+	{
 		"name": "Sehatra",
 		"uniques": ["Heals [100] damage if it kills a unit"]
 		"prerequisites": ["Sampy"],
 		"unitTypes": ["Ranged", "Mounted Ranged"]
 	},
-							{
+	{
 		"name": "Lambamena",
 		"uniques": ["[+100]% Strength <vs cities>"]
 		"prerequisites": ["Sampy"],
 		"unitTypes": ["Ranged", "Mounted Ranged"]
 	},
-								{
+	{
 		"name": "Altitude Training",
 		"uniques": ["Double movement in [Snow]", "Double movement in [Tundra]", "Double movement in [Hill]","[+10]% Strength <when fighting in [Hill] tiles>"]
 	},
-			{
+	{
 		"name": "Swift Charge",
 		"uniques": ["[+50]% Strength <vs [Melee] units>","[+25]% Strength <vs [Gunpowder] units>"],
 	},
-				{
+	{
 		"name": "Dharma",
-		"uniques": ["[-15]% Strength <when attacking>","[+10] HP when healing <in [Friendly Land] tiles>", "[+15]% Strength <when defending>"]
-				},
-								{
+		"uniques": ["[-15]% Strength <when attacking>", "[+15]% Strength <when defending>"]
+	},
+	{
 		"name": "Chain of the Earth",
 		"uniques": ["Ignores Zone of Control"]
-				},
+	},
 // PRUSSIA
 {
 		"name": "Gehorsam", // only for Kris Swordsman and subsequent upgrades

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -637,10 +637,6 @@
 	"name": "Drauhtinon",
 	"uniques": ["[+1] Movement","Heals [25] damage if it kills a unit"]
 	},
-	{
-	"name": "Hetairoi",
-	"uniques": ["Can start an [8]-turn golden age", "[+15]% Strength bonus for [Military] units within [2] tiles","Great Person - [War]"]
-	}
 		{
 		"name": "Sampy",
 		"uniques": ["Access to special promotions"]

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1046,7 +1046,7 @@
 		"requiredTech": "Civil Service",
 		"uniques": ["[+50]% Strength <vs [Mounted] units>","[+50]% Strength <vs [Mounted Ranged] units>"],
 		"upgradesTo": "Lancer",
-		"obsoleteTech": "Gunpowder",
+		"obsoleteTech": "Metallurgy",
 		"attackSound": "metalhit",
 	},
 	{
@@ -1060,7 +1060,7 @@
 		"requiredTech": "Philosophy",
 		"uniques": ["[+100]% Strength <vs [Mounted] units>","[+100]% Strength <vs [Mounted Ranged] units>"],
 		"upgradesTo": "Lancer",
-		"obsoleteTech": "Gunpowder",
+		"obsoleteTech": "Metallurgy",
 		"attackSound": "metalhit",
 	},
 		{
@@ -1074,7 +1074,7 @@
 		"requiredTech": "Civil Service",
 		"uniques": ["[+50]% Strength <vs [Mounted] units>","[+50]% Strength <vs [Mounted Ranged] units>"],
 		"upgradesTo": "Lancer",
-		"obsoleteTech": "Gunpowder",
+		"obsoleteTech": "Metallurgy",
 		"attackSound": "metalhit",
 	},
 		{
@@ -1089,7 +1089,7 @@
 		"promotions": ["Ambush Formation I"],
 		"uniques": ["Consumes [1] [Horses]","[+50]% Strength <vs [Mounted] units>","[+50]% Strength <vs [Mounted Ranged] units>"],
 		"upgradesTo": "Lancer",
-		"obsoleteTech": "Gunpowder",
+		"obsoleteTech": "Metallurgy",
 		"attackSound": "metalhit"
 	},
 	{
@@ -1988,7 +1988,7 @@
 		"cost": 330,
 		"requiredTech": "Replaceable Parts",
 		"upgradesTo": "Infantry",
-		"obsoleteTech": "Plastics",
+		"obsoleteTech": "Electronics",
 		"attackSound": "shot"
 	},
 		{
@@ -2000,7 +2000,7 @@
 		"strength": 50,
 		"cost": 330,
 		"requiredTech": "Replaceable Parts",
-		"obsoleteTech": "Plastics",
+		"obsoleteTech": "Electronics",
 		"upgradesTo": "Infantry",
 		"promotions": ["Ski Infantry","Drill I","Drill II"],
 		"attackSound": "shot"
@@ -2016,7 +2016,7 @@
 		"requiredTech": "Replaceable Parts",
 		"promotions": ["Drill I","Charge"],
 		"upgradesTo": "Infantry",
-		"obsoleteTech": "Plastics",
+		"obsoleteTech": "Electronics",
 		"attackSound": "shot"
 	},
 			{
@@ -2030,7 +2030,7 @@
 		"requiredTech": "Replaceable Parts",
 		"uniques": ["[+50]% Strength <when attacking>"]
 		"upgradesTo": "Infantry",
-		"obsoleteTech": "Plastics",
+		"obsoleteTech": "Electronics",
 		"attackSound": "shot"
 	},
 			{
@@ -2044,7 +2044,7 @@
 		"requiredTech": "Replaceable Parts",
 		"uniques": ["Heals [100] damage if it kills a unit","[+25]% Strength <when defending>","Can build [Farm] improvements on tiles"]
 		"upgradesTo": "Infantry",
-		"obsoleteTech": "Plastics",
+		"obsoleteTech": "Electronics",
 		"attackSound": "shot"
 	},
 	{

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -96,7 +96,7 @@
 		"movement": 2,
 		"cost": 75,
 		"uniques": ["Can instantly construct a [Land Trade Route (Food)] improvement <by consuming this unit>","Can instantly construct a [Land Trade Route (Production)] improvement <by consuming this unit>",
-			"Can instantly construct a [Land Trade Route (Gold)] improvement <by consuming this unit>","Consumes [1] [Trade Route]","Consumes [1] [Trade Route (Count)]","Uncapturable"],
+			"Can instantly construct a [Land Trade Route (Gold)] improvement <by consuming this unit>","Consumes [1] [Trade Route]","Consumes [1] [Trade Route (Count)]", "Only available <in cities without a [~CS]>", "Uncapturable"],
 		"requiredTech": "Animal Husbandry"
 	},
 	{
@@ -105,7 +105,7 @@
 		"movement": 4,
 		"cost": 75,
 		"uniques": ["Cannot enter ocean tiles <before discovering [Astronomy]>","Can instantly construct a [Sea Trade Route (Food)] improvement <by consuming this unit>","Can instantly construct a [Sea Trade Route (Production)] improvement <by consuming this unit>",
-			"Can instantly construct a [Sea Trade Route (Gold)] improvement <by consuming this unit>","Consumes [1] [Trade Route]","Consumes [1] [Trade Route (Count)]","Uncapturable"],
+			"Can instantly construct a [Sea Trade Route (Gold)] improvement <by consuming this unit>","Consumes [1] [Trade Route]","Consumes [1] [Trade Route (Count)]", "Only available <in cities without a [~CS]>", "Uncapturable"],
 		"requiredTech": "Sailing"
 	},
 	{
@@ -1583,7 +1583,7 @@
 		"movement": 4,
 		"cost": 200,
 		"requiredTech": "Archaeology",
-		"uniques": ["Can construct [Archaeological Dig]","Only available <if [University] is constructed>","Cannot be purchased"]
+		"uniques": ["Can instantly construct a [Archaeological Dig] improvement <by consuming this unit>","Only available <if [University] is constructed>","Cannot be purchased"]
 	},
 	{
 		"name": "Gatling Gun",
@@ -2432,7 +2432,7 @@
 		"uniqueTo": "Macedonia",
 		"unitType": "Mounted",
 		"strength": 15,
-		"promotions": ["Great Generals II","March","Charge","Heavy Charge","Hetairoi"]
+		"promotions": ["Great Generals II","March","Charge","Heavy Charge"]
 		"upgradesTo": "Knight",
 		"uniques": ["Can instantly construct a [Citadel] improvement <by consuming this unit>","Great Person - [War]", "[+15]% Strength bonus for [Military] units within [2] tiles", "Unbuildable","Consumes [1] [Horses]"],
 		"movement": 4

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -53,22 +53,14 @@
 		"name": "Pioneer", 
 		"uniqueTo": "America",
 		"replaces": "Settler",
+		"strength": 5,
 		"unitType": "Civilian",
 		"movement": 2,
 		"cost": 106,
 		"promotions": ["Ignore terrain cost"],
 		"uniques": ["Founds a new city", "Excess Food converted to Production when under construction",
-			"Requires at least [2] population"]
-	},
-		{
-		"name": "Venice Settler",
-		"unitType": "Civilian",
-		"uniqueTo": "Venice",
-		"replaces": "Settler",
-		"movement": 2,
-		"cost": 106,
-		"uniques": ["Founds a new city", "Will not be displayed in Civilopedia", "Unbuildable"],
-		"hurryCostModifier": 20
+			"Requires at least [2] population"],
+		"attackSound": "nonmetalhit"
 	},
 		
 	{
@@ -89,6 +81,21 @@
 			"[+1] Sight", "Unbuildable", "Religious Unit"
 		],
 		"movement": 3
+	},
+	{
+		"name": "Mpiambina", 
+		"uniqueTo": "Madagascar",
+		"unitType": "Ranged",
+		"replaces": "Inquisitor",
+		"movement": 3,
+		"range": 1,
+		"strength": 8,
+		"rangedStrength": 14,
+    "uniques": ["Prevents spreading of religion to the city it is next to",
+      "Can [Remove Foreign religions from your own cities] [1] times","Can be purchased with [Faith] [in all cities in which the majority religion is an enhanced religion]", "Unbuildable", "Religious Unit"
+		],
+		"promotions": ["Sampy"],
+		"attackSound": "arrow"
 	},
 	{
 		"name": "Caravan", 
@@ -123,7 +130,7 @@
 		{
 		"name": "Apedemaks Bow",
 		"replaces": "Scout",
-		"unitType": "Scout",
+		"unitType": "Ranged",
 		"uniqueTo": "Nubia",
 		"movement": 2,
 		"strength": 5,
@@ -133,8 +140,7 @@
 		"cost": 25,
 		"obsoleteTech": "Scientific Theory",
 		"promotions": ["Ignore terrain cost"],
-		"uniques": ["May upgrade to [Composite Bowman] through ruins-like effects"],
-		"attackSound": "nonmetalhit"
+		"attackSound": "arrow"
 	},
 	{
 		"name": "Pathfinder", 
@@ -171,6 +177,7 @@
 		"cost": 40,
 		"obsoleteTech": "Metal Casting",
 		"upgradesTo": "Swordsman",
+		"uniques" : ["May upgrade to [Spearman] through ruins-like effects","Can build [Farm] improvements on tiles","Can build [Quarry] improvements on tiles"],
 		"attackSound": "nonmetalhit"
 	},
 	{
@@ -182,7 +189,7 @@
 		"strength": 8,
 		"cost": 40,
 		"obsoleteTech": "Metal Casting",
-		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>", "Heals [25] damage if it kills a unit"],
+		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>", "Heals [25] damage if it kills a unit","May upgrade to [Spearman] through ruins-like effects","Ignores terrain cost <in [Forest] tiles>","Ignores terrain cost <in [Jungle] tiles>"],
 		"promotions": ["Woodsman"],
 		"upgradesTo": "Swordsman",
 		"attackSound": "nonmetalhit"
@@ -228,7 +235,7 @@
 		{
 		"name": "Matato'a",
 		"unitType": "Ranged",
-		"movement": 2,
+		"movement": 3,
 		"strength": 5,
 		"rangedStrength": 7,
 		"cost": 40,
@@ -236,7 +243,7 @@
 		"replaces": "Archer",
 		"uniqueTo": "Tonga",
 		"upgradesTo": "Composite Bowman",
-		"uniques": ["[+1] Sight","[+1] Movement"],
+		"uniques": ["[+1] Sight"],
 		"attackSound": "arrow"
 	},
 	{
@@ -313,26 +320,70 @@
 		"obsoleteTech": "Astronomy",
 		"attackSound": "nonmetalhit"
 	},
-	{
-		"name": "Galley", 
-		"unitType": "Melee Water",
-		"uniqueTo": "Barbarians",
-		"movement": 3,
-		"strength": 7,
-		"cost": 40,
-		"uniques": ["Can move after attacking","Cannot enter ocean tiles"],
-		"upgradesTo": "Trireme",
-		"attackSound": "nonmetalhit"
-	},
 		{
 		"name": "Longship", 
 		"unitType": "Melee Water",
+		"replaces": "Trireme",
 		"uniqueTo": "Denmark",
 		"movement": 6,
 		"strength": 10,
 		"cost": 45,
 		"uniques": ["Cannot enter ocean tiles","Can move after attacking"],
-		"upgradesTo": "Trireme",
+		"upgradesTo": "Caravel",
+		"obsoleteTech": "Astronomy",
+		"attackSound": "nonmetalhit"
+	},
+	{
+		"name": "Galley", 
+		"unitType": "Ranged Water",
+		"movement": 3,
+		"strength": 6,
+		"rangedStrength": 8,
+		"cost": 40,
+		"requiredTech": "Optics",
+		"uniques": ["Cannot enter ocean tiles"],
+		"upgradesTo": "Galleass",
+		"obsoleteTech": "Compass",
+		"attackSound": "nonmetalhit"
+	},
+		{
+		"name": "Dromon", 
+		"unitType": "Ranged Water",
+		"movement": 3,
+		"strength": 6,
+		"rangedStrength": 9,
+		"cost": 56,
+		"requiredTech": "Optics",
+		"uniques": ["Cannot enter ocean tiles","[+45]% Strength <vs [Water] units>","Unbuildable"],
+		"upgradesTo": "Frigate",
+		"obsoleteTech": "Astronomy",
+		"attackSound": "nonmetalhit"
+	},
+		{
+		"name": "Baghlah",
+		"uniqueTo": "Oman",
+		"replaces": "Galley", 
+		"unitType": "Ranged Water",
+		"movement": 4,
+		"strength": 8,
+		"rangedStrength": 12,
+		"cost": 56,
+		"requiredTech": "Optics",
+		"promotions": ["Coastal Raider I"],
+		"uniques": ["Cannot enter ocean tiles","Earn [100]% of killed [Military] unit's [Strength] as [Faith]","Earn [100]% of killed [Military] unit's [Strength] as [Gold]"],
+		"upgradesTo": "Galleass",
+		"obsoleteTech": "Compass",
+		"attackSound": "nonmetalhit"
+	},
+		{
+		"name": "Quinquereme",
+		"unitType": "Melee Water",
+		"movement": 4,
+		"strength": 13,
+		"requiredTech": "Sailing",
+		"uniques": ["Can move after attacking","Unbuildable"],
+		"upgradesTo": "Caravel",
+		"obsoleteTech": "Astronomy",
 		"attackSound": "nonmetalhit"
 	},
 	{
@@ -371,7 +422,7 @@
 		"movement": 5,
 		"strength": 6,
 		"rangedStrength": 10,
-		"cost": 56,
+		"cost": 55,
 		"requiredTech": "The Wheel",
 		"upgradesTo": "Knight",
 		"obsoleteTech": "Chivalry",
@@ -403,7 +454,7 @@
 		"strength": 9,
 		"rangedStrength": 9,
 		"range": 1,
-		"cost": 56,
+		"cost": 55,
 		"requiredTech": "The Wheel",
 		"upgradesTo": "Knight",
 		"attackSound": "nonmetalhit"
@@ -416,7 +467,7 @@
 		"movement": 4,
 		"strength": 7,
 		"rangedStrength": 10,
-		"cost": 56,
+		"cost": 55,
 		"requiredTech": "The Wheel",
 		"upgradesTo": "Knight",
 		"obsoleteTech": "Chivalry",
@@ -429,7 +480,7 @@
 		"unitType": "Melee",
 		"movement": 2,
 		"strength": 11,
-		"cost": 56,
+		"cost": 55,
 		"requiredTech": "Bronze Working",
 		"obsoleteTech": "Civil Service",
 		"upgradesTo": "Pikeman",
@@ -443,11 +494,11 @@
 		"unitType": "Melee",
 		"movement": 2,
 		"strength": 11,
-		"cost": 54,
+		"cost": 45,
 		"requiredTech": "Mining",
 		"obsoleteTech": "Civil Service",
 		"upgradesTo": "Pikeman",
-		"uniques": ["[+50]% Strength <vs [Mounted] units>","[+50]% Strength <vs [Mounted Ranged] units>"],
+		"uniques": ["[+50]% Strength <vs [Mounted] units>","[+50]% Strength <vs [Mounted Ranged] units>", "[+50]% to Flank Attack bonuses"],
 		"attackSound": "metalhit"
 	},
 	{
@@ -457,7 +508,7 @@
 		"unitType": "Melee",
 		"movement": 2,
 		"strength": 14,
-		"cost": 56,
+		"cost": 55,
 		"requiredTech": "Bronze Working",
 		"obsoleteTech": "Civil Service",
 		"upgradesTo": "Pikeman",
@@ -471,7 +522,7 @@
 		"unitType": "Melee",
 		"movement": 2,
 		"strength": 13,
-		"cost": 56,
+		"cost": 55,
 		"requiredTech": "Bronze Working",
 		"obsoleteTech": "Civil Service",
 		"upgradesTo": "Pikeman",
@@ -485,7 +536,7 @@
 		"unitType": "Melee",
 		"movement": 2,
 		"strength": 12,
-		"cost": 56,
+		"cost": 55,
 		"requiredTech": "Bronze Working",
 		"obsoleteTech": "Civil Service",
 		"upgradesTo": "Pikeman",
@@ -497,25 +548,14 @@
 		"name": "Pictish Warrior", 
 		"unitType": "Melee",
 		"uniqueTo": "Celts",
-		"replaces": "Warrior",
+		"replaces": "Spearman",
 		"movement": 2,
-		"strength": 10,
+		"strength": 12,
 		"cost": 45,
+		"requiredTech":"Bronze Working",
 		"obsoleteTech": "Civil Service",
-		"upgradesTo": "Swordsman",
-		"uniques":["Earn [100]% of killed [Military] unit's [Strength] as [Faith]","May upgrade to [Pictish Swordsman] through ruins-like effects"],
-		"attackSound": "metalhit"
-	},
-		{
-		"name": "Pictish Swordsman", 
-		"unitType": "Melee",
-		"uniqueTo": "Celts",
-		"movement": 2,
-		"strength": 14,
-		"cost": 75,
-		"obsoleteTech": "Civil Service",
-		"upgradesTo": "Longswordsman",
-		"uniques":["Unbuildable","Earn [100]% of killed [Military] unit's [Strength] as [Faith]"],
+		"upgradesTo": "Pikeman",
+		"uniques":["Earn [100]% of killed [Military] unit's [Strength] as [Faith]","[+20]% Strength <when fighting in [Foreign Land] tiles>","No movement cost to pillage"],
 		"attackSound": "metalhit"
 	},
 	
@@ -532,7 +572,7 @@
 		"obsoleteTech": "Physics",
 		"upgradesTo": "Trebuchet",
 		"promotions": ["Indirect Fire"],
-		"uniques": ["[+200]% Strength <vs cities>","No defensive terrain bonus","Must set up to ranged attack"],
+		"uniques": ["[+200]% Strength <vs cities>","No defensive terrain bonus","Must set up to ranged attack","[-1] Sight"],
 		"attackSound": "throw"
 	},
 	{
@@ -549,7 +589,7 @@
 		"obsoleteTech": "Physics",
 		"upgradesTo": "Trebuchet",
 		"promotions": ["Indirect Fire"],
-		"uniques": ["[+200]% Strength <vs cities>","No defensive terrain bonus","Must set up to ranged attack"],
+		"uniques": ["[+200]% Strength <vs cities>","No defensive terrain bonus","[-1] Sight"],
 		"attackSound": "throw"
 	},	
 	{
@@ -567,35 +607,6 @@
 		"uniques": ["[+200]% Strength <vs cities>","No defensive terrain bonus","Can only attack [City] units"],
 		"promotions": ["Cover I"],
 		"attackSound": "metalhit"
-	},
-		{
-		"name": "Dromon", 
-		"unitType": "Ranged Water",
-		"movement": 3,
-		"strength": 6,
-		"rangedStrength": 9,
-		"cost": 56,
-		"requiredTech": "Optics",
-		"uniques": ["Cannot enter ocean tiles","[+45]% Strength <vs [Water] units>"],
-		"upgradesTo": "Frigate",
-		"obsoleteTech": "Astronomy",
-		"attackSound": "nonmetalhit"
-	},
-			{
-		"name": "Baghlah",
-		"uniqueTo": "Oman",
-		"replaces": "Dromon", 
-		"unitType": "Ranged Water",
-		"movement": 4,
-		"strength": 8,
-		"rangedStrength": 9,
-		"cost": 56,
-		"requiredTech": "Optics",
-		"promotions": ["Coastal Raider I"],
-		"uniques": ["Cannot enter ocean tiles","[+45]% Strength <vs [Water] units>","Earn [100]% of killed [Military] unit's [Strength] as [Faith]","Earn [100]% of killed [Military] unit's [Strength] as [Gold]"],
-		"upgradesTo": "Frigate",
-		"obsoleteTech": "Astronomy",
-		"attackSound": "nonmetalhit"
 	},
 	{
 		"name": "Composite Bowman",
@@ -619,22 +630,9 @@
 		"rangedStrength": 12,
 		"cost": 75,
 		"requiredTech": "Construction",
+		"uniques": ["Can build [Tipi] improvements on tiles"],
 		"obsoleteTech": "Machinery",
 		"upgradesTo": "Crossbowman",
-		"attackSound": "arrow"
-	},
-		{
-		"name": "Mpiambina", 
-		"uniqueTo": "Madagascar",
-		"unitType": "Ranged",
-		"replaces": "Inquisitor",
-		"movement": 3,
-		"range": 1,
-		"strength": 8,
-		"rangedStrength": 14,
-                "uniques": ["Can be purchased with [Faith] [in all cities in which the majority religion is an enhanced religion]", "Unbuildable", "Religious Unit"
-		],
-		"promotions": ["Sampy"],
 		"attackSound": "arrow"
 	},
 	{
@@ -661,7 +659,7 @@
 		"hurryCostModifier": 20,
 		"requiredTech": "Iron Working",
 		"upgradesTo": "Longswordsman",
-		"uniques": ["Consumes [1] [Iron]","[+100]% Strength <when defending> <vs [Ranged] units>","Cannot attack"],
+		"uniques": ["[+100]% Strength <when defending> <vs [Ranged] units>","Cannot attack"],
 		"obsoleteTech": "Steel",
 		"attackSound": "metalhit"
 	},
@@ -686,7 +684,7 @@
 		"uniqueTo": "Rome",
 		"replaces": "Swordsman",
 		"movement": 2,
-		"strength": 17,
+		"strength": 16,
 		"cost": 75,
 		"hurryCostModifier": 20,
 		"requiredTech": "Iron Working",
@@ -787,19 +785,21 @@
 		"promotions": ["Feared Elephant","Great Generals II"],
 		"attackSound": "horse"		
 	},
-			{
-		"name": "Sarissophoroi",
-		"uniqueTo": "Macedonia",
-		"replaces": "Pikeman",
-		"unitType": "Melee",
-		"movement": 2,
-		"strength": 14,
-		"cost": 87,
-		"requiredTech": "Philosophy",
-		"uniques": ["[+100]% Strength <vs [Mounted] units>","[+100]% Strength <vs [Mounted Ranged] units>"],
-		"upgradesTo": "Musketman",
-		"obsoleteTech": "Gunpowder",
-		"attackSound": "metalhit",
+		{
+		"name": "Marathi Rider",
+		"replaces": "Horseman",
+		"uniqueTo": "Timurids",
+		"unitType": "Bomber",
+		"movement": 1,
+		"strength": 19,
+		"rangedStrength": 19,
+		"range": 5,
+		"cost": 120,
+		"requiredTech": "Chivalry",
+		"obsoleteTech": "Metallurgy",
+		"upgradesTo": "Knight",
+		"uniques": ["Consumes [1] [Horses]"],
+		"attackSound": "horse"
 	},
 	
 	// Medieval Era
@@ -843,23 +843,6 @@
 		"upgradesTo": "Gatling Gun",
 		"obsoleteTech": "Industrialization",
 		"promotions": ["Logistics"],
-		"attackSound": "arrow"
-	},
-		{
-		"name": "Ballista Elephant",
-		"unitType": "Mounted Ranged",
-		"uniqueTo": "Khmer",
-		"movement": 3,
-		"strength": 20,
-		"rangedStrength": 20,
-		"replaces": "Crossbowman",
-		"cost": 110,
-		"requiredTech": "Machinery",
-		"upgradesTo": "Gatling Gun",
-		"obsoleteTech": "Industrialization",
-		"promotions": ["Feared Elephant"],
-		"uniques": ["[+100]% Strength <vs cities>","No defensive terrain bonus",
-			"Must set up to ranged attack"],
 		"attackSound": "arrow"
 	},
 	{
@@ -908,6 +891,23 @@
 		"uniques": ["No defensive terrain bonus","Must set up to ranged attack"],
 		"attackSound": "throw"
 	},
+		{
+		"name": "Ballista Elephant",
+		"unitType": "Mounted Ranged",
+		"uniqueTo": "Khmer",
+		"movement": 3,
+		"strength": 20,
+		"rangedStrength": 20,
+		"replaces": "Trebuchet",
+		"cost": 110,
+		"requiredTech": "Machinery",
+		"upgradesTo": "Cannon",
+		"obsoleteTech": "Chemistry",
+		"promotions": ["Feared Elephant"],
+		"uniques": ["[+100]% Strength <vs cities>","No defensive terrain bonus",
+			"Must set up to ranged attack"],
+		"attackSound": "arrow"
+	},
 	{
 		"name": "Longswordsman",
 		"unitType": "Melee",
@@ -931,7 +931,7 @@
 		"requiredTech": "Theology",
 		"obsoleteTech": "Gunpowder",
 		"upgradesTo": "Musketman",
-		"uniques": ["Consumes [1] [Iron]","May enter foreign tiles without open borders","[+20]% Strength <when fighting in [Foreign Land] tiles>","Earn [150]% of killed [Military] unit's [Strength] as [Faith]"],
+		"uniques": ["Consumes [1] [Iron]","May enter foreign tiles without open borders","[+20]% Strength <when fighting in [Foreign Land] tiles>","Earn [200]% of killed [Military] unit's [Strength] as [Faith]"],
 		"attackSound": "metalhit"
 	},
 			{
@@ -940,13 +940,13 @@
 		"uniqueTo": "Normandy",
 		"unitType": "Melee",
 		"movement": 2,
-		"strength": 18,
+		"strength": 20,
 		"cost": 115,
 		"requiredTech": "Metal Casting",
 		"obsoleteTech": "Gunpowder",
 		"upgradesTo": "Musketman",
 		"promotions": ["Shock I"],
-		"uniques": ["Consumes [1] [Iron]",],
+		"uniques": ["Consumes [1] [Iron]","Can build [Motte and Bailey] improvements on tiles"],
 		"attackSound": "metalhit"
 	},
 				{
@@ -1049,6 +1049,20 @@
 		"obsoleteTech": "Gunpowder",
 		"attackSound": "metalhit",
 	},
+	{
+		"name": "Sarissophoroi",
+		"uniqueTo": "Macedonia",
+		"replaces": "Pikeman",
+		"unitType": "Melee",
+		"movement": 2,
+		"strength": 14,
+		"cost": 87,
+		"requiredTech": "Philosophy",
+		"uniques": ["[+100]% Strength <vs [Mounted] units>","[+100]% Strength <vs [Mounted Ranged] units>"],
+		"upgradesTo": "Lancer",
+		"obsoleteTech": "Gunpowder",
+		"attackSound": "metalhit",
+	},
 		{
 		"name": "Pestininkas",
 		"uniqueTo": "Lithuania",
@@ -1062,31 +1076,6 @@
 		"upgradesTo": "Lancer",
 		"obsoleteTech": "Gunpowder",
 		"attackSound": "metalhit",
-	},
-	{
-		"name": "Landsknecht",
-		"unitType": "Melee",
-		"movement": 3,
-		"strength": 16,
-		"cost": 45,
-		"requiredTech": "Civil Service",
-		"uniques": ["[+50]% Strength <vs [Mounted] units>","Only available <after adopting [Mercenary Army]>","[+50]% Strength <vs [Mounted Ranged] units>"],
-		"upgradesTo": "Lancer",
-		"attackSound": "metalhit"
-	},
-		{
-		"name": "Swiss Guard",
-		"uniqueTo": "Papal State",
-		"replaces": "Landsknecht",
-		"unitType": "Melee",
-		"movement": 3,
-		"strength": 25,
-		"cost": 65,
-		"requiredTech": "Economics",
-		"promotions": ["Medic","Medic II"],
-		"uniques": ["[+50]% Strength <vs [Mounted] units>","[+50]% Strength <vs [Mounted Ranged] units>","Earn [100]% of killed [Military] unit's [Strength] as [Faith]","Earn [100]% of killed [Military] unit's [Strength] as [Gold]"],
-		"upgradesTo": "Rifleman",
-		"attackSound": "metalhit"
 	},
 		{
 		"name": "Ulan",
@@ -1115,6 +1104,31 @@
 		"uniques": ["[+25]% Strength <vs [Gunpowder] units>","[+50]% Strength <vs [Mounted] units>","[1] additional attacks per turn","[+50]% Strength <vs [Mounted Ranged] units>"],
 		"upgradesTo": "Rifleman",
 		"obsoleteTech": "Rifling",
+		"attackSound": "metalhit"
+	},
+	{
+		"name": "Landsknecht",
+		"unitType": "Melee",
+		"movement": 3,
+		"strength": 16,
+		"cost": 45,
+		"requiredTech": "Civil Service",
+		"uniques": ["[+50]% Strength <vs [Mounted] units>","Only available <after adopting [Mercenary Army]>","[+50]% Strength <vs [Mounted Ranged] units>"],
+		"upgradesTo": "Lancer",
+		"attackSound": "metalhit"
+	},
+		{
+		"name": "Swiss Guard",
+		"uniqueTo": "Papal State",
+		"replaces": "Landsknecht",
+		"unitType": "Melee",
+		"movement": 3,
+		"strength": 25,
+		"cost": 65,
+		"requiredTech": "Economics",
+		"promotions": ["Medic","Medic II"],
+		"uniques": ["[+50]% Strength <vs [Mounted] units>","[+50]% Strength <vs [Mounted Ranged] units>","Earn [100]% of killed [Military] unit's [Strength] as [Faith]","Earn [100]% of killed [Military] unit's [Strength] as [Gold]"],
+		"upgradesTo": "Rifleman",
 		"attackSound": "metalhit"
 	},
 	{
@@ -1159,34 +1173,19 @@
 		"attackSound": "horse"
 	},
 		{
-		"name": "Marathi Rider",
-		"replaces": "Horseman",
-		"uniqueTo": "Timurids",
-		"unitType": "Bomber",
-		"movement": 1,
-		"strength": 21,
-		"rangedStrength": 21,
-		"range": 4,
-		"cost": 120,
-		"requiredTech": "Chivalry",
-		"obsoleteTech": "Flight",
-		"upgradesTo": "Great War Bomber",
-		"uniques": ["Consumes [1] [Horses]"],
-		"attackSound": "horse"
-	},
-		{
 		"name": "Konnitsa",
 		"uniqueTo": "Bulgaria",
 		"replaces": "Knight",
 		"unitType": "Mounted",
 		"movement": 4,
 		"strength": 20,
+		"rangedStrength": 20,
 		"cost": 120,
 		"requiredTech": "Chivalry",
 		"obsoleteTech": "Military Science",
 		"upgradesTo": "Cavalry",
 		"uniques": ["Can move after attacking","No defensive terrain bonus",
-			"[-33]% Strength <vs cities>","Consumes [1] [Horses]","[+1] additional attacks per turn"],
+			"[-33]% Strength <vs cities>","Consumes [1] [Horses]"],
 		"attackSound": "horse"
 	},
 	{
@@ -1203,19 +1202,6 @@
 		"upgradesTo": "Cavalry",
 		"uniques": ["Can move after attacking","No defensive terrain bonus","Consumes [1] [Horses]"],
 		"attackSound": "arrow"
-	},
-	{
-		"name": "Conquistador",
-		"unitType": "Mounted",
-		"movement": 4,
-		"strength": 20,
-		"cost": 135,
-		"requiredTech": "Chivalry",
-		"obsoleteTech": "Military Science",
-		"upgradesTo": "Cavalry",
-		"uniques": ["Only available <after adopting [Exploration]>","Can move after attacking","No defensive terrain bonus","Founds a new city",
-			"[+2] Sight","Defense bonus when embarked","Consumes [1] [Horses]"],
-		"attackSound": "horse"
 	},
 		{
 		"name": "Mamluk",
@@ -1291,20 +1277,17 @@
 		"promotions": ["Great Generals I","Quick Study"],
 		"attackSound": "arrow"
 	},
-		{
-		"name": "Dhow",
-		"replaces": "Caravel",
-		"uniqueTo": "Kilwa",
-		"unitType": "Melee Water",
+	{
+		"name": "Conquistador",
+		"unitType": "Mounted",
 		"movement": 4,
-		"strength": 17,
-		"cost": 105,
-		"hurryCostModifier": 30,
-		"requiredTech": "Compass",
-		"upgradesTo": "Ironclad",
-		"obsoleteTech": "Combustion",
-		"promotions": ["Boarding Party I"],
-		"uniques": ["[+1] Sight","Can move after attacking","May withdraw before melee ([50]%)"],
+		"strength": 20,
+		"cost": 135,
+		"requiredTech": "Chivalry",
+		"upgradesTo": "Cavalry",
+		"uniques": ["Only available <after adopting [Exploration]>","Can move after attacking","No defensive terrain bonus","Founds a new city",
+			"[+2] Sight","Defense bonus when embarked","Consumes [1] [Horses]"],
+		"attackSound": "horse"
 	},
 	
 	// Rennaisance Era
@@ -1335,12 +1318,27 @@
 		"obsoleteTech": "Combustion",
 		"uniques": ["Can move after attacking","Cannot enter ocean tiles"],
 	},
+		{
+		"name": "Dhow",
+		"replaces": "Caravel",
+		"uniqueTo": "Kilwa",
+		"unitType": "Melee Water",
+		"movement": 4,
+		"strength": 17,
+		"cost": 105,
+		"hurryCostModifier": 30,
+		"requiredTech": "Compass",
+		"upgradesTo": "Ironclad",
+		"obsoleteTech": "Combustion",
+		"promotions": ["Boarding Party I"],
+		"uniques": ["[+1] Sight","Can move after attacking","May withdraw before melee ([50]%)"],
+	},
 	{
 		"name": "Nau", 
 		"uniqueTo": "Portugal",
 		"replaces": "Caravel",
 		"unitType": "Melee Water",
-		"movement": 5,
+		"movement": 6,
 		"strength": 20,
 		"cost": 120,
 		"hurryCostModifier": 30,
@@ -1459,11 +1457,25 @@
 		"uniques": ["[+50]% Strength <vs [Mounted] units>","[+50]% Strength <vs [Mounted Ranged] units>"],
 		"attackSound": "shot"
 	},
+	{
+		"name": "Carolean", 
+		"replaces": "Musketman",
+		"unitType": "Gunpowder",
+		"uniqueTo": "Sweden",
+		"movement": 2,
+		"strength": 24,
+		"cost": 150,
+		"requiredTech": "Gunpowder",
+		"obsoleteTech": "Rifling",
+		"upgradesTo": "Rifleman",
+		"promotions": ["March"],
+		"attackSound": "shot"
+	},
 {
 		"name": "Privateer",
 		"unitType": "Melee Water",
 		"movement": 5,
-		"strength": 27,
+		"strength": 25,
 		"cost": 150,
 		"requiredTech": "Navigation",
 		"upgradesTo": "Destroyer",
@@ -1481,7 +1493,7 @@
 		"cost": 150,
 		"requiredTech": "Navigation",
 		"upgradesTo": "Destroyer",
-		"promotions": ["Coastal Raider I", "Coastal Raider II", "Supply"],
+		"promotions": ["Boarding Party I", "Coastal Raider I", "Supply"],
 		"uniques": ["May capture killed [Water] units"]
 	},
 	{
@@ -1571,7 +1583,7 @@
 		"upgradesTo": "Anti-Tank Gun",
 		"uniques": ["Can move after attacking","No defensive terrain bonus",
 			"[-33]% Strength <vs cities>","Consumes [1] [Horses]"],
-		"promotions": ["Shock I","Ambush Formation I","Heavy Charge"],
+		"promotions": ["Ambush Formation I","Heavy Charge"],
 		"attackSound": "horse"
 	},
 	
@@ -1606,7 +1618,7 @@
 		"range": 2,
 		"movement": 2,
 		"strength": 31,
-		"rangedStrength": 30,
+		"rangedStrength": 31,
 		"cost": 225,
 		"requiredTech": "Industrialization",
 		"upgradesTo": "Machine Gun",
@@ -1646,7 +1658,7 @@
 		"replaces": "Rifleman",
 		"unitType": "Melee",
 		"movement": 2,
-		"strength": 29,
+		"strength": 32,
 		"cost": 180,
 		"requiredTech": "Metallurgy",
 		"obsoleteTech": "Replaceable Parts",
@@ -1661,7 +1673,7 @@
 		"replaces": "Rifleman",
 		"unitType": "Melee",
 		"movement": 2,
-		"strength": 29,
+		"strength": 35,
 		"cost": 180,
 		"requiredTech": "Military Science",
 		"obsoleteTech": "Replaceable Parts",
@@ -1681,22 +1693,8 @@
 		"requiredTech": "Industrialization",
 		"obsoleteTech": "Replaceable Parts",
 		"replacementTextForUniques": "Can construct Roads, Railroads, Forts and remove: Forest, Marsh and Jungle tiles", 
-		"uniques": ["Can build [All Road] improvements on tiles","Can build [Fort] improvements on tiles","Can build [Remove Marsh] improvements on tiles",],
+		"uniques": ["Can build [All Road] improvements on tiles","Can build [Fort] improvements on tiles","Can build [Remove Marsh] improvements on tiles","Can build [Remove Jungle] improvements on tiles","Can build [Remove Forest] improvements on tiles"],
 		"upgradesTo": "Great War Infantry",
-		"attackSound": "shot"
-	},	
-	{
-		"name": "Carolean", 
-		"replaces": "Musketman",
-		"unitType": "Gunpowder",
-		"uniqueTo": "Sweden",
-		"movement": 2,
-		"strength": 24,
-		"cost": 150,
-		"requiredTech": "Rifling",
-		"obsoleteTech": "Replaceable Parts",
-		"upgradesTo": "Great War Infantry",
-		"promotions": ["March"],
 		"attackSound": "shot"
 	},
 	{
@@ -1720,23 +1718,21 @@
 		"uniqueTo": "Ireland",
 		"unitType": "Gunpowder",
 		"movement": 2,
-		"strength": 34,
+		"strength": 40,
 		"cost": 165,
 		"requiredTech": "Rifling",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Great War Infantry",
-		"uniques": ["[+20]% Strength <when fighting in [Friendly Land] tiles>"],
 		"attackSound": "shot"
 	},
 	{
 		"name": "Carrier",
 		"unitType": "Aircraft Carrier",
 		"movement": 5,
-		"strength": 70,
-		"rangedStrength": 70,
-		"cost": 420,
+		"strength": 40,
+		"cost": 375,
 		"requiredTech": "Electronics",
-                "uniques": ["Can carry [2] [Aircraft] units","Cannot attack"]
+    "uniques": ["Can carry [2] [Aircraft] units","Cannot attack"]
 	},
 	{
 		"name": "Triplane",
@@ -1746,7 +1742,7 @@
 		"rangedStrength": 35,
 		"range": 5,
 		"interceptRange": 5,
-		"cost": 330,
+		"cost": 325,
 		"requiredTech": "Flight",
 		"upgradesTo": "Fighter",
 		"obsoleteTech": "Radar",
@@ -1761,7 +1757,7 @@
 		"strength": 50,
 		"rangedStrength": 50,
 		"range": 6,
-		"cost": 330,
+		"cost": 325,
 		"requiredTech": "Flight",
 		"obsoleteTech": "Radar",
 		"upgradesTo": "Bomber",
@@ -1793,7 +1789,7 @@
 		"obsoleteTech": "Combustion",
 		"upgradesTo": "Landship",
 		"uniques": ["Can move after attacking","No defensive terrain bonus",
-			"[-33]% Strength <vs cities>","[+33]% Strength <vs [Wounded] units>","Consumes [1] [Horses]"],
+			"[-33]% Strength <vs cities>","[+25]% Strength <vs [Wounded] units>","Consumes [1] [Horses]"],
 		"attackSound": "horse"
 	},
 	{
@@ -1802,7 +1798,7 @@
 		"replaces": "Cavalry",
 		"uniqueTo": "Manchuria",
 		"movement": 5,
-		"strength": 34,
+		"strength": 36,
 		"cost": 225,
 		"requiredTech": "Military Science",
 		"obsoleteTech": "Combustion",
@@ -1877,13 +1873,13 @@
 		"replaces": "Artillery",
 		"unitType": "Siege",
 		"movement": 2,
-		"strength": 24,
+		"strength": 23,
 		"rangedStrength": 28,
 		"range": 3,
 		"cost": 250,
 		"requiredTech": "Dynamite",
 		"upgradesTo": "Rocket Artillery",
-		"uniques": ["[+200]% Strength <vs cities>","[+25]% Strength <vs [Melee] units>","[+25]% Strength <vs [Gunpowder] units>","No defensive terrain bonus",
+		"uniques": ["[+200]% Strength <vs cities>","No defensive terrain bonus",
 			"[-1] Sight","Ranged attacks may be performed over obstacles"]
 	},
 	{
@@ -1918,7 +1914,7 @@
 		"rangedStrength": 45,
 		"range": 8,
 		"interceptRange": 8,
-		"cost": 420,
+		"cost": 375,
 		"requiredTech": "Radar",
 		"upgradesTo": "Jet Fighter",
 		"promotions": ["Air Recon"],
@@ -1933,7 +1929,7 @@
 		"strength": 65,
 		"rangedStrength": 65,
 		"range": 10,
-		"cost": 420,
+		"cost": 375,
 		"requiredTech": "Radar",
 		"upgradesTo": "Stealth Bomber",
 		"uniques": ["Consumes [1] [Oil]"],
@@ -1948,7 +1944,7 @@
 		"requiredTech": "Combustion",
 		"obsoleteTech": "Combined Arms",
 		"upgradesTo": "Tank",
-		"uniques": ["Can move after attacking","[+50]% Strength <vs [Land] units>","No defensive terrain bonus","Consumes [1] [Oil]"]
+		"uniques": ["Can move after attacking","[+50]% Strength <vs [Land] units>","[-33]% Strength <vs cities>","No defensive terrain bonus","Consumes [1] [Oil]"]
 	},
 	{
 		"name": "Destroyer",
@@ -1965,12 +1961,11 @@
 		"unitType": "Ranged Water",
 		"movement": 5,
 		"strength": 55,
-		"rangedStrength": 55,
+		"rangedStrength": 65,
 		"range": 3,
-		"cost": 420,
+		"cost": 375,
 		"requiredTech": "Electronics",
-		"uniques": ["Ranged attacks may be performed over obstacles","[+100]% Strength <vs [Submarine] units>",
-			"[+30]% Strength <vs cities>","Consumes [1] [Oil]"]
+		"uniques": ["Ranged attacks may be performed over obstacles","Consumes [1] [Oil]"]
 	},
 	{
 		"name": "Submarine",
@@ -1978,7 +1973,7 @@
 		"movement": 5,
 		"strength": 35,
 		"rangedStrength": 60,
-		"cost": 360,
+		"cost": 325,
 		"requiredTech": "Refrigeration",
 		"upgradesTo": "Nuclear Submarine",
 		"obsoleteTech": "Telecommunications",
@@ -2033,7 +2028,7 @@
 		"strength": 47,
 		"cost": 330,
 		"requiredTech": "Replaceable Parts",
-		"uniques": ["[+15]% Strength <when attacking>"]
+		"uniques": ["[+50]% Strength <when attacking>"]
 		"upgradesTo": "Infantry",
 		"obsoleteTech": "Plastics",
 		"attackSound": "shot"
@@ -2130,7 +2125,7 @@
 		"requiredTech": "Combined Arms",
 		"obsoleteTech": "Lasers",
 		"upgradesTo": "Modern Armor",
-		"uniques": ["Can move after attacking","[+50]% Strength <vs [Land] units>","No defensive terrain bonus","Consumes [1] [Oil]"]
+		"uniques": ["Can move after attacking","[+50]% Strength <vs [Land] units>","[-33]% Strength <vs cities>","No defensive terrain bonus","Consumes [1] [Oil]"]
 	},
 	{
 		"name": "Panzer",
@@ -2142,7 +2137,7 @@
 		"cost": 450,
 		"requiredTech": "Combined Arms",
 		"obsoleteTech": "Lasers",
-		"uniques": ["Can move after attacking","No defensive terrain bonus","[+50]% Strength <vs [Land] units>","Consumes [1] [Oil]"]
+		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>","[+50]% Strength <vs [Land] units>","Consumes [1] [Oil]"]
 	},
 	{
 		"name": "Anti-Tank Gun",
@@ -2256,7 +2251,7 @@
 		"movement": 3,
 		"interceptRange": 2,
 		"strength": 65,
-		"cost": 510,
+		"cost": 425,
 		"requiredTech": "Rocketry",
 		"uniques": ["[100]% chance to intercept air attacks","[+150]% Strength <vs [Air] units>"],
 		"attackSound": "machinegun"
@@ -2266,7 +2261,7 @@
 		"unitType": "Helicopter",
 		"movement": 6,
 		"strength": 60,
-		"cost": 510,
+		"cost": 425,
 		"requiredTech": "Computers",
 		"uniques": ["[+200]% Strength <vs [Armored] units>","All tiles costs 1",
 			"No defensive terrain bonus","Can move after attacking",
@@ -2279,7 +2274,7 @@
 		"unitType": "Gunpowder",
 		"movement": 3,
 		"strength": 90,
-		"cost": 450,
+		"cost": 375,
 		"requiredTech": "Mobile Tactics",
 		"attackSound": "shot"
 	},
@@ -2288,10 +2283,10 @@
 		"unitType": "Armored",
 		"movement": 5,
 		"strength": 100,
-		"cost": 540,
+		"cost": 425,
 		"requiredTech": "Lasers",
 		"upgradesTo": "Giant Death Robot",
-		"uniques": ["Can move after attacking","[+50]% Strength <vs [Land] units>","No defensive terrain bonus","Consumes [1] [Aluminum]"]
+		"uniques": ["Can move after attacking","[+50]% Strength <vs [Land] units>","[-33]% Strength <vs cities>","No defensive terrain bonus","Consumes [1] [Aluminum]"]
 	},
 	{
 		"name": "Nuclear Submarine", 
@@ -2300,7 +2295,7 @@
 		"strength": 50,
 		"range": 3,
 		"rangedStrength": 85,
-		"cost": 510,
+		"cost": 425,
 		"requiredTech": "Telecommunications",
 		"uniques": ["[+75]% Strength <when attacking>", "Invisible to others", 
 			"Can only attack [Water] tiles", "Can see invisible [Submarine] units", "Can enter ice tiles", 
@@ -2314,20 +2309,20 @@
 		"rangedStrength": 100,
 		"range": 3,
 		"interceptRange": 2,
-		"cost": 510,
+		"cost": 425,
 		"requiredTech": "Robotics",
 		"promotions": ["Indirect Fire"],
-		"uniques": ["[100]% chance to intercept air attacks","Can see invisible [Submarine] units","Can carry [2] [Missile] units"]
+		"uniques": ["[100]% chance to intercept air attacks","Can see invisible [Submarine] units","Can carry [3] [Missile] units"]
 	},
 	{
 		"name": "Jet Fighter", 
 		"unitType": "Fighter",
-		"movement": 2,
-		"strength": 45,
+		"movement": 1,
+		"strength": 75,
 		"rangedStrength": 75,
 		"range": 10,
 		"interceptRange": 10,
-		"cost": 540,
+		"cost": 425,
 		"requiredTech": "Lasers",
 		"uniques": ["[+150]% Strength <vs [Helicopter] units>","[100]% chance to intercept air attacks","[+150]% Strength <vs [Bomber] units>","Consumes [1] [Aluminum]"],
 		"promotions": ["Air Recon"]
@@ -2337,11 +2332,11 @@
 		"unitType": "Bomber",
 		"movement": 2,
 		"strength": 85,
-		"rangedStrength": 65,
+		"rangedStrength": 85,
 		"range": 20,
-		"cost": 540,
+		"cost": 425,
 		"requiredTech": "Stealth",
-		"promotions": ["Evasion"],
+		"promotions": ["Evasion","Air Recon"],
 		"uniques": ["Consumes [1] [Aluminum]"],
 		"attackSound": "shot"
 	},
@@ -2350,10 +2345,10 @@
 		"unitType": "Armored",
 		"movement": 5,
 		"strength": 150,
-		"cost": 600,
+		"cost": 425,
 		"requiredTech": "Nuclear Fusion",
 		"promotions": ["Interception III"],
-		"uniques": ["Can move after attacking","No defensive terrain bonus","[+50]% Strength <vs [Land] units>","Consumes [1] [Uranium]"],
+		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>","[+50]% Strength <vs [Land] units>","Consumes [1] [Uranium]"],
 		"attackSound": "shot"
 	},
 		{
@@ -2361,7 +2356,7 @@
 		"unitType": "Gunpowder",
 		"movement": 2,
 		"strength": 100,
-		"cost": 510,
+		"cost": 400,
 		"requiredTech": "Nanotechnology",
 		"uniques": ["May Paradrop up to [40] tiles from inside friendly territory"],
 		"attackSound": "shot"
@@ -2383,6 +2378,13 @@
 		"unitType": "Civilian",
 		"uniques": ["Empire enters a [12]-turn Golden Age <by consuming this unit>", "Can instantly construct a [Landmark] improvement <by consuming this unit>","Uncapturable", "Great Person - [Culture]", "Unbuildable"],
 		"movement": 4
+	},
+	{
+		"name": "Great Prophet",
+		"unitType": "Civilian",
+		"uniques": ["Can instantly construct a [Holy site] improvement <by consuming this unit> <if it hasn't used other actions yet>", "Can [Spread Religion] [4] times", "Removes other religions when spreading religion", "May found a religion", "May enhance a religion", "May enter foreign tiles without open borders", "Great Person - [Faith]", "Religious Unit", "Unbuildable"],
+		"movement": 4,
+		"religiousStrength": 1000
 	},
 			{
 		"name": "Dalai Lama",
@@ -2438,16 +2440,6 @@
 		"movement": 4
 	},
 	{
-		"name": "Merchant of Venice", 
-		"uniqueTo": "Venice",
-		"replaces": "Great Merchant",
-		"unitType": "Civilian",
-		"movement": 4,
-		"cost": 250,
-		"uniques": ["Can undertake a trade mission with City-State, giving a large sum of gold and [120] Influence",
-			"Can instantly construct a [Customs house] improvement <by consuming this unit>","Double movement in [Coast]","Uncapturable", "Great Person - [Gold]", "Unbuildable"]
-	},
-	{
 		"name": "Khan",
 		"unitType": "Civilian",
 		"uniqueTo": "Mongolia",
@@ -2456,13 +2448,6 @@
 		"uniques": ["[+15]% Strength bonus for [Military] units within [2] tiles",
 			 "Can instantly construct a [Citadel] improvement <by consuming this unit>","Uncapturable", "Great Person - [War]", "Unbuildable"],
 		"movement": 7
-	},
-	{
-		"name": "Great Prophet",
-		"unitType": "Civilian",
-		"uniques": ["Can instantly construct a [Holy site] improvement <by consuming this unit> <if it hasn't used other actions yet>", "Can [Spread Religion] [4] times", "Removes other religions when spreading religion", "May found a religion", "May enhance a religion", "May enter foreign tiles without open borders", "Great Person - [Faith]", "Religious Unit", "Unbuildable"],
-		"movement": 4,
-		"religiousStrength": 1000
 	},
 	{
 		"name": "Great Admiral", 


### PR DESCRIPTION
Main goal of this PR is to remove stub buildings that originally set up capital related uniques. The reasons are

> Buildings that require actually building or purchasing unintentionally affects balance

> Buildings may seem different to what it should be when viewing the city stars

> Having things split across the mod can lead to certain things being easily missable. An example is that Maya actually had a completely different unique to what the uniqueText claimed

> In general, this is also a move towards removing almost all uniqueText entirely, which makes it easier to show stat symbols

Other changes in thing PR include cleaning up 2 things misses in the last PR (such as an oddly placed promotion), reverting Byzantium and Maya to how they function in Civ 5/Unciv, and updating Boer and The Golden Horde to their current Lekmod versions