### PR TITLE
Update UnitPromotions.json

### DIFF
--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -794,7 +794,7 @@
     {
         "name": "Swift Charge",
         "uniques": [
-            "[+50]% Strength <vs [Melee] units>",
+            "[+50]% Strength <vs [Sword] units>",
             "[+25]% Strength <vs [Gunpowder] units>"
         ]
     },


### PR DESCRIPTION
It looks like that with "Melee" units in Civ5/Lekmod, they mean what we would call "Sword" units in Unciv.