### PR TITLE
minimal translation

### DIFF
--- a/jsons/translations/Korean.properties
+++ b/jsons/translations/Korean.properties
@@ -1,78 +1,182 @@
+#################### Lines from Beliefs.json ####################
+
+Alters of Worship = 예배 전환
+Earth Mother = 대지모신
+Goddess of the Fields = 땅의 여신
+God-King = 신왕
+Harvest Festival = 수확제
+Mystic Rituals = 신비 의식
+Ocean's Bounty = 바다의 은혜
+Rain Dancing = 빗물의 춤
+Rite of Spring = 봄의 제전
+Ritual Sacrifice = 희생제의
+Seafood Rituals = 해산물 제전
+Spirit Animals = 동물의 얼
+Spirit Trees = 나무의 얼
+Starlight Guidance = 별빛의 인도
+Sun God = 태양신
+Tears of the Gods = 신들의 눈물
+Vision Quests = 환상 탐색
+Work Spirituals = 영적인 업무
+
+Dawah = 초대하는 선교
+Mithraea = 지하 성소
+Salat = 실천 기도
+Zakat = 기부 의무
+
+Devoted Elite = 엘리트의 헌신
+Devout Performers = 독실한 공연
+Followers of Refined Crafts = 공예품 수집가
+Gurdwaras = 황금 사원
+Mandirs = 만신전
+Synagogues = 집회당
+Viharas = 사찰
+
+Apostolic Palace = 교황궁
+City of God = 신의 도시
+Disciples = 문하생
+Hajj = 성지순례
+Houses of Worship = 예배 거점
+Indulgences = 면죄부
+Jesuit Education = 회당 교육
+Jizya = 지즈야
+Karma = 카르마
+Kotel = 통곡의 벽
+Religious Troubadours = 종교 음악가
+Sacred Sites = 성스러운 건물들
+Underground Sect = 지하 종파
+Unity of the Prophets = 선지자 단결
+Work Ethic = 직업윤리
 
 #################### Lines from Buildings.json ####################
 
-Water Mill = 물레방앗간
+Falu Gruva = 팔루 채광장
+Grand Canal of Venice = 베니스 대운하
+Grand Cathedral of Vilnius = 빌니우스 대성당
+Mysore Palace = 마이소르 궁전
+King Ezana's Stele = 에즈나 왕의 스텔레
+Orszaggyules = 두개의 집
+Saint Peter's Basilica = 성 피터의 바실리카
 
-+4% great person generation in all cities = 모든 도시에서 위인 출현율 +4%
-Can only be built in coastal cities = 해안 도시에만 건설 가능
-Garden = 정원
-
-Arsenal = 병기창
-
-Military Base = 군사 기지
-
-'It is not so much for its beauty that the forest makes a claim upon men's hearts, as for that subtle something, that quality of air, that emanation from old trees, that so wonderfully changes and renews a weary spirit.' - Robert Louis Stevenson = '인간이 숲을 동경하는 이유는 그저 숲이 아름다워서가 아니라 오래된 숲의 고목에서 뿜어져 나오는 공기에 존재하는 미묘한 무엇인가가 사람의 지친 영혼에 활기를 불어넣어 주고 회복시켜 주기 때문이다.' - 로버트 루이스 스티븐슨
-+10% Growth in all Cities. = 모든 도시에 식량 생산량 +10%
-+15% Production towards Ranged Units. = 원거리 유닛 생산시 생산력 +15%
-Temple of Artemis = 아르테미스 사원
-
-+1 Science Per 2 Population = 인구 2당 +1 과학
-Royal Library = 왕립 도서관
-
-Coffee House = 커피 하우스
-
-Floating Gardens = 수상 정원
-
-Ceilidh Hall = 연회장
-
-Stele = 스텔레
-
+Akkadian Library = 아카드식 도서관
+Alcazaba = 궁전요새
+Baray = 인공 수역
+Basilica = 바실리카
+Blast Furnace = 고로
+BMPC Plant = BMPC 공단
 Candi = 찬디
-
-Pyramid = 마야 피라미드
-
-+15% Production when building Mounted Units in this city = 이 도시에서 기병 유닛을 생산할 때 생산량 +15%
+Canton Factory = 주립 공장
+Ceilidh Hall = 세일리드 홀
+Convict Penitentiary = 죄수 노역장
+Coral Port = 산호항
+Cothon = 군용 내항
+Darbas = 다르바스 공동체
+Dojo = 도장
 Ducal Stable = 공작의 마굿간
-
+Fabrik = 파브릭
+Feitoria = 페이토리아
+Hacienda = 농원
+Halkevleri = 계몽 센터
+Hanse = 한자
+Hippodrome = 경주장
+Irish Pub = 아일랜드식 주점
+Khambar = 캄바르
+Knyaz Court = 왕자의 법정
+Kyawwat = 콰우와트
+Lion's Gate = 사자의 문
+Madrasah = 마드라사
+Mala'e = 말랴레
+Mead Hall = 연회장
+Minaa = 미나아
+Murus Gallicus = 갈리아 벽
 Ikanda = 이칸다
+Ocupada Estable = 분주한 마구간
+Odeon = 오데온
+Outremer = 해방원
+Painted Monastery = 채색 수도원
+Pillar of Ashoka = 아소카의 기둥
+Plaza de Toros = 투우장
+Quara U'y = 유목 마장
+Rova = 로바
+Royal Library = 왕립 도서관
+Sauna = 사우나
+Serai = 세라이
+Silversmith = 은세공장
+Slave Market = 노예 시장
+Spomenik = 기념관
+Staatsmuseum = 주립 박물관
+Stade = 바이킹 정착지
+Stone Mason = 석공촌
+Stave Church = 목조 교회
+Tim Hortons = 팀홀튼
+Trade Harbor = 무역 항만
+Vo Khi = 봇키
+Yam Route = 얌 교역로
+Yeshiva = 예시바
+Ziggurat = 지구라트
 
-East India Company = 동인도회사
-Grand Temple = 대사원
-National Visitor's Center = 외국인 관광 안내소
+Art Hall = 예술의 전당
+Ayyubid Burial Tomb = 아이유브 왕릉
+Fine Art Specialist = 예술 전문가들
+Governor's Mansion = 통치거택
+Gurdwara = 황금 사원
+Mandir = 만신전
+Synagogue = 집회당
+Vihara = 사찰
+Vocal Chamber = 가수 구역
+Watch Tower = 감시탑
+Writing Auditorium = 작문 강당
 
+Althing = 오로라 회의
+Artist Guild = 예술가 조합
+Borobudur = 보로부드루
+Broadway = 브로드웨이
+Center of Progress = 발전 중심지
+East India Company = 동인도 회사
+Globe Theatre = 글로브 극장
+Huey Teocalli = 후웨이 피라미드
+Musician Guild = 음악가 조합
+Panama Canal = 파나마 운하
 Parthenon = 파르테논 신전
-'Earth proudly wears the Parthenon as the best gem upon her zone.' - Ralph Waldo Emerson = 파르테논 신전이야말로 지구에 있는 기념물중 으뜸이다. - 랄프 왈도 에머슨
-
-Petra = 페트라
-'...who drinks the water I shall give him, says the Lord, will have a spring inside him welling up for eternal life. Let them bring me to your holy mountain in the place where you dwell. Across the desert and through the mountain to the Canyon of the Crescent Moon...' - Indiana Jones = ...내가 주는 물을 마시는 자는 불로장생할 것이니 사람들이 나를 네가 있는 성스러운 산으로 인도하도록 할 지어다. 사막을 가로지르고 산을 넘으면 초승달 계곡이 나오는데... - 인디아나 존스
-
+Prora = 프로라
 Red Fort = 붉은 요새
-'When we build, let us think that we build forever.'   –- John Ruskin = 뭔가를 지을 때는 영원히 남길 생각으로 지어야 한다. - 존 러스킨
+Uffizi = 우피지
+Writer Guild = 작가 조합
 
-Prora = 프로라 해변 리조트
-'This loss (of freedom) means the fading from human life of values infinitely precious to it. There only remain ironbound conditions of employment and trivial amusements for leisure.'  - A.N. Whitehead = (자유의) 상실은 인간이 가장 소중히 여기는 가치관이 몰락했음을 뜻한다. 이후로는 고용자와 피고용자의 엄격한 관계에 얽매여 사소한 즐거움만을 누릴 뿐이다. - A.N. 화이트헤드
-
-Great Mosque of Djenne = 젠네 모스크
-With the magnificence of eternity before us, let time, with all its fluctuations, dwindle into its own littleness.  – Thomas Chalmers = 무한이라는 장엄한 개념 앞에서 변동이 심한 시간이라는 개념은 작아질 수밖에 없다 - 토마스 챌머스
-
-CN Tower = CN 타워
-'Nothing travels faster than the speed of light with the possible exception of bad news, which obeys its own special laws.' - Douglas Adams = 물리학에서 빛보다 빠른 물체는 없다. 그러나 나쁜 소식은 빛보다 빠를 수 있다. 이는 소식이 퍼지는 데 특별한 법칙이 적용되기 때문이다. - 더글러스 애덤스
-
-Hotel = 호텔
-Mosque = 모스크
-Recycling Center = 재활용 센터
-
+Brewery = 양조장
+Caravansary = 역참
+Censer Maker = 향로 제조장
+Gemcutter = 보석 세공인
+Grocer = 잡화상
+Oil Refinery = 오일 정제장
+Textile Mill = 섬유 공장
+Zoo = 동물원
 
 #################### Lines from Nations.json ####################
 
+#Akkad#
+Sargon = 사르곤
+The Great Unification = 대통합
+
+Aksum = 악숨
+Ezana = 에즈나
+Saint Elesbaan's Blessing = 성 엘레스반의 축복
+
+#America#
+#Arabia#
+[+1 Gold] from every Trade Route\n\nDouble quantity of [Oil] produced = 무역로마다 [+1 Gold]\n\n[Oil] 채굴량 2배
+
+Argentina = 아르헨티나
+Eva Peron = 에비타
+Pride of the People = 민중의 긍지
+
+Armenia = 아르메니아
+Tiridates III = 티리다테스 3세
+Splendor of the Caucasus = 찬란한 코카서스
+
 Assyria = 아시리아
 Ashurbanipal = 아슈르바니팔
-I fear there is no other choice but to remove you from this world! = 
-I think you will come to regret this decision...most unwise. = 
-We may be defeated, but our legacy will live on in the written word! = 
-I welcome you to the great kingdom of Assyria...have you come to view my library? = 
-Will you consider a trade? = 
-? = 
+Siege Warfare = 공성 체계
 Assur = 아수르
 Nineveh = 니네베
 Nimrud = 니므루드
@@ -100,58 +204,30 @@ Kelashin = 켈라신
 Urartu = 타드모르
 Sabata = 사바타 
 Hit = 히트
-Treasures of Nineveh = 니네베의 보물
-When a city is conquered, gain a free Technology. Gaining a city through a trade deal does not count. = 도시를 정복한 후 해당 도시의 소유자가 발견한 기술 중 하나를 얻습니다. 거래로 도시를 얻는 것은 해당하지 않으며, 적 도시 하나당 한 번만 일어납니다.
 
-Austria = 오스트리아
-Maria Theresa = 마리아 테레지아
-Shame that it has come this far. But ye wished it so. = 
-What a fool ye are! Ye will end swiftly and miserably. = 
-The world is pitiful! There's no beauty in it, no wisdom. I am almost glad to go. = 
-The archduchess of Austria welcomes your Eminence to... Oh let's get this over with! I have a luncheon at four o'clock. = 
-I see you admire my new damask. Nobody should say that I am an unjust woman. Let's reach an agreement! = 
-Hello! = 
-Oh, it's ye! = 
-Vienna = 빈
-Salzburg = 잘츠부르크
-Graz = 그라츠
-Linz = 린츠
-Klagenfurt = 클라겐푸르트
-Bregenz = 브레겐츠
-Innsbruck = 인스브룩
-Kitsbühel = 키츠뷔엘
-St. Pölten = 장크트필텐
-Eisenstadt = 아이젠슈타트
-Villach = 필라흐
-Zwettl = 츠페틀
-Traun = 트라운
-Weis = 벨스
-Dombim = 도른비른
-Feldkirch = 펠트키르히
-Amstetten = 암슈테텐
-Bad Ischl = 바트이슐
-Wolfsberg = 볼프스부르크
-Kufstein = 쿠브슈타인
-Leoben = 레오벤
-Klosterneuburg = 클로스터노이부르크
-Leonding = 레온딩
-Kapfenberg = 카펜베르트
-Hallein = 할라인
-Bischofshofen = 비쇼프스호펜
-Saalbach = 잘아흐
-Lienz = 린츠
-Steyr = 슈타이아
-Diplomatic Marriage = 정략 결혼
-Cost of purchasing items in cities reduced by [15]% = 도시에서 구매하는 가격이 [15]% 감소
+Australia = 호주
+Henry Parker = 헨리 파커
+Dreamtime = 몽환시
+
+#Austria#
+
+Ayyubids = 아이유브
+Saladin = 살라딘
+Justice of Saladin = 살라딘의 통치
+
+#Aztecs#
+#Babylon#
+
+Belgium = 벨기에
+Leopold II = 레오폴드 2세
+Colonialist Riches = 식민주의의 치부
+
+Boers = 보어
+Stephanus Johannes Paulus Kruger = 폴 크루거
+The Great Trek = 위대한 여정
 
 Brazil = 브라질
 Pedro II = 페드루 2세
-Your reign will be better under MY domain. = 
-I worry about all those who are affected by this conflict. = 
-This is why I prefer diplomacy to violence... = 
-I am Pedro, Emperor of Brazil. I have little time for pleasantries, what brings you here? = 
-Should we prosper through commerce? = 
-Hello. = 
 Rio de Janeiro = 레오데자네이루
 Sao Paulo = 상파울루
 Salvador = 살바도르
@@ -187,272 +263,78 @@ Juiz de Fora = 주이즈데포라
 Joinville = 주앵빌
 Jundiaí = 쥬쟈이
 Carnival = 카니발
-[Great Artist] is earned [25]% faster = [Great Artist]를 [25]% 빨리 얻음
 
-Byzantine = 비잔틴
-Byzantium = 비잔틴
-Theodora = 테오도라
-It has always been a shame throwing away beauty. Thankfully, not like that. = 
-Now that riots are needed, friend, we'll teach you a lesson. = 
-I hope you knew that to act like that. Just know that in this world nobody will aid a traitor. = 
-Oh! A miracle in front of my eyes. What is the name of this good stranger? I am Theodora, friend of Byzantium. = 
-I heard nice things from you in your latest sayings...show me. = 
-Sweet. = 
-Constantinople = 콘스탄티노플
-Adrianople = 아드리아노플
-Nicaea = 니케아
-Antioch = 안티오크
-Varna = 바르나
-Ohrid = 오흐리드
-Nicomedia = 니코메니아
-Trebizond = 트레비존드
-Cherson = 케르손
-Sardica = 사르디카
-Ani = 아니
-Dyrrachium = 디라키움
-Edessa = 에데사
-Chalcedon = 칼케돈
-Naissus = 나이수스
-Bari = 바리
-Iconium = 이코늄
-Prilep = 프릴레프
-Samosata = 사모사타
-Kars = 카르스
-Nicopolis = 니코폴리스
-Theodosiopolis = 테오도시오폴리스
-Tyana = 타이아나
-Gaza = 가자
-Kerkyra = 케르키라
-Phoenice = 포에니케
-Selymbria = 셀림브리아
-Sillyon = 실리욘
-Chrysopolis = 크리소폴리스
-Vodena = 보데나
-Caesarea Maritima = 카이사리아 마리티마
-Traianoupoli = 트라야누폴리
-Constantia = 콘스탄티아
-Korinthos = 코린토스
-Patra = 파트라
-Patriarchate of Constantinople = 콘스탄티노플 총대주교
-Receive a free policy when you reach Civil Service = 공공 행정 기술을 완료할 때 무료 사회정책 하나를 받습니다
+Brunei = 브루나이
+Bolkiah = 볼키아
+Sea Nomads = 바다 유목민
+-33% maintenance costs for Water units\n\nWater units may heal outside of friendly territory\n\nWater units can build Water improvements on tiles = 수상 유닛 유지비 -33%\n\n수상 유닛이 우호 지역 밖에서도 회복 가능\n\n수상 유닛은 수상 타일 개발이 가능
 
-Carthage = 카르타고
-Dido = 디도
-Tell me, do you all know how numerous my armies, elephants and the gdadons are? No? Today, you shall find out! = 
-Fate is against you. You earned the animosity of Carthage in your exploration. Your days are numbered. = 
-The fates became to hate me. This is ? You wouldn't destroy us so without their help. = 
-The Phoenicians welcome you to this most pleasant kingdom. I am Dido, the queen of Carthage and all that belongs to it. = 
-I had an idea and I realized I should tell it to you! = 
-It is done. = 
-What is it now? = 
-Utique = 우티쿠
-Hippo Regius = 히포레기우스
-Gades = 가데스
-Saguntum = 사군툼
-Carthago Nova = 카르타고노바
-Panormus = 파노르무스
-Lilybaeum = 릴리바리움
-Hadrumetum = 하드루메툼
-Zama Regia = 자마레기아
-Karalis = 카랄리스
-Malaca = 말라카
-Leptis Magna = 렙티스마그나 
-Hippo Diarrhytus = 히포다이리투스
-Motya = 모티아
-Sulci = 술키
-Tharros = 타로스
-Leptis Parva = 렙티스파바
-Soluntum = 소룬툼
-Lixus = 릭서스
-Oea = 오에아
-Theveste = 테베스테
-Ibossim = 이보심
-Thapsus = 탑수스
-Aleria = 알레이아
-Tingis = 틴기스
-Abyla = 아빌라
-Sabratha = 사브라타
-Rusadir = 루사디르
-Baecula = 베쿨라
-Saldae = 살대
-Phonenician Heritage = 페니키아의 계승자
-All coastal Cities get a free Harbor = 도시마다 항만이 무료로 제공 됩니다
+Bulgaria = 불가리아
+Asparukh Khan = 아스파르후 칸
+Cyrillic Script = 키릴 문자
 
-Celts = 켈트
-Boudicca = 부디카
-I've been watching you, you devious pigs! To guard patriots! March to war! = 
-How dare you! I will be the one owning your head. = 
-Evil King! You realized that you won this war in name only? = 
-I am Boudicca, Queen of the Celts and nobody better try rushing me! = 
-Let us unite our armies, and profit from the challenges. = 
-God has given good to you. = 
-Well? = 
-Edinburgh = 에든버러
-Dublin = 더블린
-Cardiff = 카디프
-Truro = 트루로
-Nantes = 낭트
-Douglas = 더글라스
-Glasgow = 글래스고 
-Cork = 고크
-Aberystwyth = 에버리스트위스
-Penzance = 펜잔스
-Rennes = 렌
-Ramsey = 램지
-Inverness = 인버네스
-Limerick = 리머릭
-Swansea = 스완지
-St. Ives = 세인트아이브
-Brest = 브레스트
-Peel = 필
-Aberdeen = 애버딘
-Belfast = 벨파스트
-Caernafon = 커나번
-Newquay = 뉴키
-Saint-Nazarre = 세인트나제흐
-Castletown = 캐슬타운
-Stirling = 스털링
-Galway = 골웨이
-Conwy = 콘위
-St. Austell = 세인트오스틀
-Saint-Malo = 세인트말로
-Onchan = 온찬
-Londonderry = 런던데리
-Llanfairpwllgwyngyll = 랜바이어푸흘귄기흘
-Falmouth = 팔머스
-Lorient = 로리앙
-Druidic Lore = 드루이드교 전승
+Burma = 버마
+Anawratha = 아나우라타
+Pyu City States = 퓨 도시국가들
 
-The Netherlands = 네덜란드 
-William I = 윌리엄
-As much as I despise war, I consider it a, hahaha, contribution to the common cause to erase your existence. = 
-You call yourself an exalted ruler, but I see nothing more than a smartly dressed barbarian! = 
-My God, be merciful to my soul. My God, feel pity for this... my poor people! = 
-I am William of Orange, stadtholder of The Netherlands. Did you need anything? I still have a lot to do. = 
-I believe I have something that may be of some importance to you. = 
-Once again, greetings. = 
-Amsterdam = 암스테르담
-Rotterdam = 로테르담
-Utrecht = 위트레흐트
-Groningen = 흐로닝언
-Breda = 브레다
-Nijimegen = 네이메헨
-Den Haag = 헤이그
-Haarlem = 하를럼
-Arnhem = 아른험
-Zutphen = 주트펜
-Maastricht = 마스트리히트
-Tilburg = 틸뷔르흐
-Eindhoven = 아인트호벤
-Dordrecht = 도르드레흐트
-Leiden = 라이덴
-Hertogenbosch = 스헤르토헨보스
-Almere = 알미르
-Alkmaar = 알크마르
-Brielle = 브릴르
-Vlissingen = 폴리싱겐
-Apeldoorn = 아펠두른
-Nova Enschede = 
-Sao Bernardo do Amersfoort = 아메르스포르트
-Zwolle = 주올라
-Venlo = 벤로
-Uden = 우덴
-Grave = 그라베
-Delft = 델프트
-Gouda = 고우다
-Nieuwstadt = 뉴웨스타드
-Weesp = 위스프
-Coevorden = 쿠하르든
-Kerkrade = 케르크라데
-Dutch East India Company = 네덜란드 동인도회사
-All Cities provide 1 extra copy of each improved luxury resource = 
+#Byzantium#
 
-Ethiopia = 에티오피아
-Haile Selassie = 하일레 셀라시에
-I tried so many ways but you continue doing craziness. I wish you a fast ending. = 
-Mean people silence, makes them a winner. We will not sit and watch you do whatever you wish. = 
-Today, God and history will remember your action. You are ready to do wrongful judgment. = 
-Dear fellow nation, welcome. I am Emperor Haile Selassie Ras Teferi Mekonnen of Ethiopia, your sincere server. = 
-This situation, you better think as I believe for both our people, it is very important and useful. = 
-Welcome. = 
-Addis Ababa = 아디스아바바
-Harar = 하라르
-Adwa = 아드와
-Lalibela = 랄리벨라
-Gondar = 곤다르
-Axum = 악숨
-Dire Dawa = 디레다와
-Bahir Dar = 바히르다르
-Adama = 아다마
-Mek'ele = 멕엘레
-Awasa = 아와사
-Jimma = 짐마
-Jijiga = 지지가
-Dessie = 데시
-Debre Berhan = 데브레버한
-Shashamane = 샤샤메인
-Debre Zeyit = 데브레제이트
-Sodo = 소도
-Hosaena = 호사이나
-Nekemte = 네켐테
-Aselia = 아셀라
-Dila = 딜라
-Adigrat = 아디그라트
-Debre Tabor = 데브레타보르
-Sebeta = 세베타
-Shire = 샤이어
-Ambo = 암보
-Negele Arsi = 네겔레아르시 
-Gambela = 감벨라
-Ziway = 지웨이
-Weldiya = 웰디아
-Spirit of Adwa = 아두와 전투의 정신
-+15% combat strength for units fighting in friendly territory = 우호적 영토에서 전투시 전투력 +15%
+Canada = 캐나다
+John A. MacDonald = 존 맥도날드 경
+Canadian Fur Trade = 캐나다의 모피 무역
 
-The Huns = 훈족
-Attila = 
- I'm getting bored of this throne of mine. I will take YOURS instead. = 
-Now what is this?! You ask me to add your riches to my great avails. The invitation is accepted. = 
- My people will mourn me not with tears but with human blood. = 
-You are now in front of Attila, the misfortunes of the city of Rome. = 
-Come here! There are lots of agreement papers to do. = 
-They received well. = 
-Attila's Court = 아틸라 궁정
-Washington = 워싱턴
-Mecca = 메카
-Babylon = 바빌론
-Beijing = 베이징
-Copenhagen = 코펜하겐
-Thebes = 테베
-London = 런던
-Paris = 파리
-Berlin = 베를린
-Athens = 아테네
-Cusco = 쿠스코
-Delhi = 델리
-Onoondaga = 
-Kyoto = 교토
-Seoul = 서울
-Karakorum = 
-Istanbul = 이스탄불
-Persepolis = 페르세폴리스
-Honolulu = 호놀룰루
-Rome = 로마
-Moscow = 모스크바
-Sukhothai = 
-Gao = 가오
-Madrid = 마드리드
-Scourge of God = 신의 재앙
+#Carthage#
+#Celts#
+#China#
+#Denmark#
+#Egypt#
+#England#
+#Ethiopia#
+
+Finland = 핀란드
+Mannerheim = 만네르헤임
+Finnish Mobility = 핀식 기동
+
+#France#
+City of Light = 빛의 도시
+
+Franks = 프랑크
+Charlemagne = 샤를마뉴
+Holy Roman Empire = 신성 로마 제국
+
+Gaul = 골
+Vercingetorix = 웨르킨게토릭스
+Oppidum of Bibracte = 요새화 정착지
+
+#Germany#
+Precision Engineering = 정밀공학
+
+Golden Horde = 황금 군단
+Batu Khan = 바투 칸
+Golden Conquest = 황금의 정복
+
+Goths = 고트
+Alaric I = 알라릭 1세
+Drauhtinon = 전쟁의 시간
+
+#Greece#
+Pericles = 페리클레스
+
+Hittites = 히타이트
+Muwatallis = 무와탈리
+Bronze and Iron = 청동과 철
+
+#The Huns#
+
+Hungary = 헝가리
+Andras II = 안드라스 2세
+Verszerzodes = 피의 맹세
+
+#Inca#
+#India#
 
 Indonesia = 인도네시아
 Gajah Mada = 가자 마다
-Don't mean to stand in your way, but I have to protect them! = 
-How dare you! Really insignificant as well! = 
-You may win, but you cannot win upon my spirit. = 
-You came before the great warrior, Gajah Mada from Nusantara! = 
-What if we make a deal, you and me? = 
-Greetings! = 
-Are you a male concubine, stranger? = 
 Jakarta = 자카르타
 Surabaya = 수라바야
 Medan = 메단
@@ -482,75 +364,81 @@ Cimahi = 씨마히
 Balikpapan = 발릭파판
 Jambi = 잠비
 Komodo = 코모도
-Solo = 
-Biak = 
-Djawa = 
-Kudus = 
-Lombok = 
-Samosir = 
-Sragen = 
-Garut = 
-Gresik = 
-Nias = 
-Madiun = 
 Yogyakarta = 욕야카르타
-Bima = 
-Sorong = 
 Spice Islanders = 향로의 섬
-After researching Astronomy, 3 coastal cities provide additional 'luxuries' which provide gold and happiness = 천문학 기술을 연구한 후, 3개의 해안 도시는 금과 행복을 제공하는 추가적인 사치자원을 제공합니다
+Gain access to buildings that provides 2 copies of unique Luxury Resources = 고유 사치 자원을 2개씩 생성
 
-The Maya = 마야
-Pacal = 파칼
-A sacrifice unlike all others must be made! = 
-Today comes pain that is always hot. With you comes the path to the black storm. = 
-Greetings, wayward one. I am known as Pacal. = 
-Friend, I believe I may have found a way to save us all! Look, look and accept my offering! = 
-Fine day; it helps you. = 
-Palenque = 팔렌케
-Tikal = 티칼
-Chichen Itza = 치첸 이트사
-Uxmal = 우쉬말
-Tulum = 툴룸
-Copan = 코판
-Coba = 코바
-El Mirador = 엘 미라도르
-Calakmul = 칼라크물
-Edzna = 에즈나
-Lamanai = 라마나이
-Izapa = 이사파
-Uaxactun = 우악삭툰
-Comalcalco = 코말칼코
-Piedras Negras =
-Cancuen = 
-Yaxha = 약사
-Quirigua = 키리구아
-Q'umarkaj = 우말카하
-Nakbe = 나크비
-Cerros = 세로스
-Xumantunich = 주난투니치
-Takalik Abaj = 타칼릭 아바
-Cival = 시발
-San Bartolo = 산 바르톨로 
-Altar de Sacrificios = 희생의 제단
-Seibal = 세이발
-Caracol = 카라콜
-Naranjo = 나란호
-Dos Pilas = 도스필라스
-Mayapan = 마야판
-Ixinche = 이신테
-Zaculeu = 자쿨레우
-Kabah = 카바
-The Long Count = 마야 장기력
-After researching Theology, receive a bonus Great Person at the end of every Maya Long Count calendar cycle (every 394 years) = 신학 연구 후 마야 장기력의 한 주기(394년)가 끝날 때마다 보너스로 위인이 출현합니다.(한번 선택한 위인 선택 불가)
+Ireland = 아일랜드
+Michael Collins = 마이클 콜린스
+Gaelic Revival = 게일의 부흥
+[+2 Happiness] from all National Wonders (excluding the Palace).\n\n+15% [Production] towards constructing buildings required for National Wonders. = (궁전을 제외한) 국가 원더에서 [+2 Happiness]\n\n국가 원더 건설때 +15% [Production]
+
+#Iroquois#
+
+Israel = 이스라엘
+David = 다윗
+The Promised Land = 약속의 땅
+
+Italy = 이태리
+Vittorio Emanuele III = 비토리오 에마누엘레 3세
+Rinascimento = 르네상스
+
+#Japan#
+
+#Jerusalem#
+Fulk V = 펄크 5세
+The Holy Land = 성스러운 땅
+
+Khmer = 크메르
+Suryavarman II = 수리야바르만 2세
+Grand Baray of Angkor = 앙코르의 거대 수역
+
+Kilwa = 킬와
+Ali ibn al-Hassan Shirazi = 알리 이븐 알-하산 시라지
+Merchant Economy = 상인 경제
++10% Growth in all cities.\n\n[+4 Gold] from [Food] and [Production] Trade Routes = 모든 도시에서 성장률 +10%\n\n[Food]와 [Production] 교역로에서 [+4 Gold]
+
+Kongo = 콩고
+Mvemba a Nzinga = 음벰바 아 은징가
+Heart of Africa = 아프리카의 심장
+
+#Korea#
+
+Lithuania = 리투아니아
+Vytautas = 비타우타스
+Baltic Mythology = 발트 신화
+All Great Prophets generated by Lithuania become the Krivis, which can create the Sacred Grove = 리투아니아의 위대한 선지자는 성스러운 숲을 만들 수 있는 크리비스가 됨
+
+Macedonia = 마케도니아
+Macedonian Discipline = 마케도니아의 규율
+
+Madagascar = 마다가스카르
+Ralambo = 랄람보
+Sacred Hills of Imerina = 이메리나의 신성한 언덕
+
+Manchuria = 만주
+Nurhaci = 누르하치
+Eight Banners = 팔기군
+
+Maurya = 마우리
+Ashoka = 아소카
+Insriptions of the Dharma = 달마의 비문
+Non-Air Units receive a -15% Combat Penalty when attacking, and a +15% Combat Bonus when defending = 공중 유닛을 제외한 모든 유닛이, 공격시 전투력 -15%, 방어시 전투력 +15%
+
+#The Maya#
+
+Mexico = 멕시코
+Benito Juarez = 베니토 후아레스
+Encomienda System = 정복자의 권리
+
+#Mongolia#
+
+The Moors = 무어
+Abd-ar-Rahman III = 압드 알라흐만 3세
+Glory of Al-Andalus = 알-안달루스의 영광
 
 Morocco = 모로코
 Ahmad al-Mansur = 아흐마드 알만수르
-The gain from the war, what will you get out of it? = 
-Shame on you, using violence which doesn't solve anything. = 
-The gain is having a clean system from corruption. = 
-I am the Sultan of Marrakesh Ahmad Al-Mansur, in the name of my people I welcome you! = 
-I came with all hope, but haven't reached an agreement. = 
-What are you doing here? = 
 Marrakech = 마라케시
 Rabat = 라바트
 Fes = 페스
@@ -586,17 +474,44 @@ Ben Guerir = 벤 구에리르
 Eli Kelaa des Sraghna = 엘 캘라 드 스라그나
 Erfoud = 에르포드
 Gateway to Africa = 아프리카의 관문
-[+3 Gold, +1 Culture] from each Trade Route = 다른 문명이나 도시국가에 연결된 교역로 하나마다 [+3 Gold, +1 Culture]
+[+4 Gold, +2 Culture] from every [Gold] Trade Route\n\n[+1 Gold, +1 Culture] from every [Gold] Trade Route from each era = [Gold] 무역로마다 [+4 Gold, +2 Culture]\n\n시대가 올라갈때마다 [Gold] 무역로에서 추가로 [+1 Gold, +1 Culture]
+
+Mysore = 마이소르
+Hyder Ali = 하이더 알리
+Brahmin Elite = 보스턴 엘리트
+
+#The Netherlands#
+
+Normandy = 노르망디
+William the Conqueror = 정복자 윌리엄
+Castle Builders = 성 짓는 사람들
+
+Norway = 노르웨이
+Harald Hardrada = 하랄드 하르드라다
+Nordic Bounty = 노르드의 은혜
+
+Nubia = 누비아
+Amanitore = 아마니토레
+Ta-Seti = 타세티
+
+Oman = 오만
+Saif bin Sultan = 사이프 빈 술탄
+Chain of the Earth = 지구의 사슬
+
+#The Ottomans#
+
+Papal State = 교황령
+Urban II = 우르반 2세
+The Holy See = 성스러운 시야
+
+#Persia#
+
+Phoenicia = 페니키아
+Hiram = 히람
+Skillful Traders = 완숙한 무역상
 
 Poland = 폴란드
 Caismir III = 카지미에시 3세
-I have decided to end you! = 
-My armies will grind you to dust! = 
-Celebrate your victory well...it might be your last one. = 
-I, Casimir the Great, welcome you to the lands of the Great Kingdom of Poland. = 
-How do you like my offer? = 
-I salute you. = 
-What are you looking for here? = 
 Warsaw = 바르샤바
 Kraków = 크라쿠프
 Łódź = 우치
@@ -632,18 +547,11 @@ Wałbrzych = 바우브지흐
 Zielona Góra = 지엘로나 구라
 Włocławek = 브워츠와베크
 Solidarity = 연대
-[+4 Culture] in capital = 수도에서 [+4 Culture]
-Culture cost of adopting new Policies reduced by 10% = 새 사회청책을 체택할 때, 비용 10% 감소
+
+#Polynesia#
 
 Portugal = 포르투갈
 Maria I = 마리아 1세
-I'm afraid I cannot allow your kingdom to exist for much longer! I hope you won't mind... = 
-You cannot be serious! = 
-I know little about this conflict...I'll have to consult my regent... = 
-I am Maria, Queen of Portugal! Have we met before? You look familiar to me... Or maybe not. = 
-Will you consider this offer? = 
-Good morning. = 
-Why did you come? = 
 Lisbon = 리스본
 Porto = 포르투
 Braga = 브라가
@@ -675,16 +583,24 @@ Dili = 딜리
 Lamego = 라메구
 Ponta Delgada = 풍가델가다
 Mare Clausum = 닫힌 지중해
-Gold from all trade routes +25% = 모든 교역로에서 금 +25%
+
+Prussia = 프러시아
+Frederick = 프레데릭
+Army with a State = 국가가 있는 군대
+
+Romania = 루마니아
+Carol I = 캐롤 1세
+Nihil Sine Deo = 하나님 없이는 아무것도 아니다
+
+#Rome#
+#Russia#
+
+Scotland = 스코틀랜드
+Robert the Bruce = 로버트 1세
+Flower of Scotland = 스코틀랜드의 꽃
 
 Shoshone = 쇼숀
 Pocatello = 포카텔로
-Shoshone!, We will kill the white man! = 
-I must make the foreigner go away! = 
-This will not be the end of my people, I assure you. = 
-I am Chief Pocatello. You have arrived in the thick of Shoshone land. = 
-Would you listen to my proposal? = 
-Our time has arrived! = 
 Moson Kahni = 모손 카흐니
 Te-Moak = 테모악
 Agaidika = 아가이디카
@@ -711,126 +627,65 @@ Skull Valley = 스컬 벨리
 Big Pine = 빅 파인
 Duck Valley = 덕 밸리
 Great Expanse = 대확장
-Increased rate of border expansion. Units receive a combat bonus when fighting in their own territory = 국경 확장의 빈도수 증가. 자신의 영역에서 싸우는 유닛은 전투력 보너스를 받음
 
-Sweden = 스웨덴
-Gustavus Adolphus = 구스타부스 아돌푸스
-The Hakkapeliittas will ride again and your men will fall just at the sight of my cavalry! = 
-Ha ha ha, captain Gars will be very glad to head out to war again. = 
-I am Sweden's king. You can take my lands, my people, my kingdom, but you will never reach the House of Vasa. = 
-Stranger, welcome to the Snow King's kingdom! I am Gustavus Adolphus, member of the esteemed House of Vasa. = 
-My friend, it is my belief that this settlement can benefit both our peoples. = 
-Oh, welcome! = 
-Oh, it is you. = 
-Stockholm = 스톡홀롬
-Sigtuna = 시그투나
-Helsinki = 헬싱키
-Birka = 비르카
-Uppsala = 웁살라
-Turku = 트르쿠
-Linköping = 린셰핑
-Lund = 룬드
-Espoo = 에스포
-Malmö = 말뫼
-Vantaa = 반타
-Visby = 비스비
-Strängnäs = 스트랭나스
-Tampere = 탐페레
-Skara = 스카라
-Lödöse = 뢰되세
-Oulu = 오울루
-Växjö = 벡셰
-Jyväskylä = 유배스큘래이
-Gothenburg = 예테보리
-Örebro = 오베브로
-Lahti = 라티
-Helsingborg = 헬싱보리
-Jönköping = 이왼체핑
-Kuopio = 쿠오피오
-Norrköping = 노르셰핑
-Sundsvall = 선즈발
-Kouvola = 쿠볼라
-Karlstad = 칼스타드
-Umeå = 우메오
-Pori = 포리
-Ystad = 위스타드
-Paviken = 파비켄
-Vaasa = 바사
-Nobel Prize = 노벨상
-+[30]% great person generation in all cities = 모든 도시에서 위인 출현률 +[30]%
+#Siam#
 
-Venezia = 베네치아
+Sioux = 수우
+Sitting Bull = 앉은 황소
+Dwellers of the Plains = 평원의 거주자들
+
+#Songhai#
+#Spain#
+
+Sumeria = 수메르
+Gilgamesh = 길가메시
+Cradle of Civilization = 문명의 요람
+
+#Sweden#
+
+Tibet = 티베트
+Ngawang Lobsang Gyatso = 5대 달라이 라마
+Eightfold Path to Nirvana = 열반의 여덟 길
+[+2 Faith, +2 Food, +2 Culture, +2 Production, +2 Science, +2 Gold] in the capital after discovering [Drama and Poetry].\n\n[+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith] in the capital after discovering [Education], [Acoustics], [Industrialization], [Radio], [Radar] and [Telecommunications] = [Drama and Poetry] 연구 뒤, 수도에서 [+2 Faith, +2 Food, +2 Culture, +2 Production, +2 Science, +2 Gold]\n\n[Education], [Acoustics], [Industrialization], [Radio], [Radar], [Telecommunications] 연구 뒤, 수도에서 각각 [+1 Food, +1 Culture, +1 Production, +1 Science, +1 Gold, +1 Faith]
+
+Timurids = 티무리즈
+Timur = 티무르
+Ulugh Beg's Observatory = 울루베그 천문대
+
+#Tonga#
+'Aho'eitu = 아호 에이투
+The Friendly Islands = 끈끈한 군도
+
+Turkey = 튀르키예
+Ataturk = 아타튀르크
+Westernization = 서구화 과업
+
+Ukraine = 우크라이나
+Yaroslav I = 야로슬라브 1세
+The Way of Chumaks = 무역상의 길
+
+#Venice#
 Enrico Dandolo = 엔리코 단돌로
-When you will be gone, Sir, there will be more for me! = 
-You have revealed your purposes too early, my friend! = 
-A wrong calculation, on my part. = 
-Welcome to Venice. I am Doge Enrico Dandolo. = 
-This offer won't be valid for a lot of time, think about it. = 
-Greetings. = 
-You! What do you want? = 
-Venice = 베네치아
-Aarhus = 
-Kaupang = 
-Ribe = 
-Viborg = 
-Tunsbers = 
-Roskilde = 
-Hedeby = 
-Oslo = 
-Jelling = 
-Truso = 
-Bergen = 
-Faeroerne = 
-Reykjavik = 
-Trondheim = 
-Godthab = 
-Helluland = 
-Lillehammer = 
-Markland = 
-Elsinore = 
-Sarpsborg = 
-Odense = 
-Aalborg = 
-Stavanger = 
-Vorbasse = 
-Schleswig = 
-Kristiansand = 
-Halogaland = 
-Randers = 
-Fredrikstad = 
-Kolding = 
-Horsens = 
-Tromsoe = 
-Vejle = 
-Koge = 
-Sandnes = 
-Holstebro = 
-Slagelse = 
-Drammen = 
-Hillerod = 
-Sonderborg = 
-Skien = 
-Svendborg = 
-Holbaek = 
-Hjorring = 
-Fladstrand = 
-Haderslev = 
-Ringsted = 
-Skrive = 
 Serenissima = 세레니시마
-Cannot build Settlers = 개척자를 생산할 수 없습니다.
-+[100]% [Gold] from every [Palace] = 모든 [Palace]에서 [Gold] +[100]%
-Receive free [Merchant of Venice] when you discover [Optics] = [Optics]를 연구하면 [Merchant of Venice]이 출현합니다
+
+Vietnam = 베트남
+Pham Van Dong = 팜반동
+Tam Giao = 세 개의 가르침
+
+Wales = 웨일스
+wain Glyndwr = 오와잉 글린덜
+Hafod a Hendref = 헨드레프 하포드랑께
+
+Yugoslavia = 유고슬라비아
+Aleksandar I = 알렉산다르 1세
+Non-Aligned Doctrine = 비동맹 독트린
+
+Zimbabwe = 짐바브웨
+Nyatsimba Mutot = 냐스티마 무토트
+Great Zimbabwe = 위대할 짐바브웨
 
 Zulu = 줄루
 Shaka = 샤카
-None will slow our progress, not even you! Prepare for war! = 
-Your arrogance will only lead you to defeat! = 
-My warriors have failed, and so I failed them. = 
-I'm Shaka of Zulu. Don't try to move, warrior, or I'll destroy you. = 
-Approve the closure sell. = 
-Hail your Majesty! = 
-You say? What are you doing here? = 
 Ulundi = 울룬디
 Umgungundlovu = 움군군들로부
 Bulawayo = 불라와요
@@ -866,276 +721,339 @@ Maseru = 마세루
 Lobamba = 로밤바
 Qunu = 쿠누
 Iklwa = 이클와
--25% land units maintenance = 지상유닛 유지비 -25%
-Military units gain 50% more Experience from combat = 군사 유닛은 전투로부터 50%경험치를 더 받습니다
 
+Baku = 아제르바이잔
+Chaco Canyon = 차코
+Djibouti = 지부티
+Kuala Lumpur = 말레이시아
+Kuwait City = 쿠웨이트
+Kyzyl = 키질
+Ljubljana = 슬로베니아
+Luxembourg = 룩셈부르크
+Monaco = 모나코
+Montevideo = 우루과이
+Nicosia = 키프로스
+Reykjavik = 아이슬란드
+Teheran = 이란
+Thimphu = 부탄
+Bangkok = 태국
+Cape Town = 남아공
+Islamabad = 파키스탄
+Kampala = 우간다
+Lima = 페루
+Lusaka = 잠비아
+Mogadishu = 소말리아
+Ormus = 오르무스
+Panama City = 파나마
+Paramaribo = 수리남
+Phnom Penh = 캄보디아
+Port-au-Prince = 아이티
+Riga = 라트비아
+Santo Domingo = 도미니카
+Cahokia = 카호키아
+Colombo = 스리랑카
+Dubai = 아랍에미리트
+Gaborone = 보츠와나
+Hong Kong = 홍콩
+Lagos = 나이지리아
+Malacca = 말레이시아
+Maseru = 레소토
+Mohenjo-Daro = 모헨조다로
+Singapore = 싱가포르
+Tallinn = 에스토니아
+Trieste = 트리에스테
+Vaduz = 리히텐슈타인
+Zurich = 취리히
+Andorra = 안도라
+Colchis = 콜키스
+Cyrene = 키레네
+Harappa = 파키스탄
+Havana = 쿠바
+Tirana = 알바니아
+Troy = 트로이
+Valletta = 몰타
+Geneva = 제네바
+Ife = 이페
+Kathmandu = 네팔
+La Venta = 라벤타
+Qufu = 쿠푸
+Sarajevo = 사라예보
+Taipei = 대만
+Wittenberg = 비텐베르크
 
 #################### Lines from Policies.json ####################
 
+Religious Tolerance = 종교적 관용
+
+#Aesthetics#
+Cultural Centers = 문화 센터
+Cultural Exchange = 문화 교류
+Artistic Genius = 예술의 천재
+Flourishing of the Arts = 예술 번영
+Fine Arts = 순수 예술
+
+#Patronage#
+Merchant Confederacy = 상인 연합
+Scholasticism = 스콜라 철학
+Cultural Diplomacy = 문화 외교
+Philanthropy = 자선사업
+Consulates = 영사관
+
 Exploration = 탐험
-All military naval units receive +1 movement and +1 sight = 모든 군사 해양 유닛은 +1 이동력 +1 시야
-Unlocks building the Louvre = 루부르 박물관 불가사의를 해금한다
-
+#Naval Tradition#
 Maritime Infrastructure = 해안 공공시설
-
-Naval Tradition = 해안 혈통
-
-Merchant Navy = 상선대
-
+Colonialism = 식민주의
 Navigation School = 항해 학교
+Treasure Fleets = 보물선단
 
-Treasure Fleets = 보물 선단
+#Commerce#
+Silk Road = 비단길
+Mercenary Army = 용병군
+Entrepreneurship = 기업가 정신
+#Mercantilism#
+#Protectionism#
 
-Exploration Complete = 탐험 완료
-
-Order = 체제
-Unlocks building the Kremlin = 크렘린 불가사의를 해금
-
-United Front = 통일 전선
-
-Socialism = 사회주의
-
-Nationalism = 민족주의
-+15% combat strength for units fighting in friendly territory = 아군 영토에서 싸우는 유닛에 +15% 전투력 보너스
-
-Planned Economy = 계획 경제
-
+#Order#
+Hero of the People = 인민 영웅
+Socialist Realism = 사회주의 리얼리즘
+Patriotic War = 대조국전쟁
+Double Agents = 이중간첩
+Young Pioneers = 피오네르 소년단
+Party Leadership = 당 지도부
+Resettlements = 재정착
+Skyscrapers = 마천루
+Academy of Sciences = 과학 아카데미
+Cultural Revolution = 문화대혁명
+Workers Faculties = 노동자 시설
+Five-Year Plan = 5개년 계획
+People's Army = 인민의 군대
 Communism = 공산주의
+Iron Curtain = 철의 장막
+Spaceflight Pioneers = 우주비행 개척자
+Order I Complete = 질서 나 완성
 
-Order Complete = 체제 완료
+#Freedom#
+Avant Garde = 아방가르드
+Creative Expression = 독창적 표현
+#Civil Society#
+Covert Action = 비밀 공작
+Capitalism = 자본주의
+Economic Union = 경제 동맹
+Arsenal of Democracy = 민주주의의 병기창
+Volunteer Army = 의용군
+Urbanization = 도시화
+Free Mind = 자유로운 사고
+#Universal Suffrage#
+New Deal = 뉴딜 정책
+Universal Healthcare = 국민 의료보험
+Media Culture = 미디어 문화
+Treaty Organization = 조약 기구
+Space Procurements = 우주 사업 조달
+Freedom I Complete = 평등 나 완성
 
+#Autocracy#
+Elite Forces = 정예 부대
+Mobilization = 동원령
+#United Front#
+Futurism = 미래파
+Industrial Espionage = 산업 스파이
+#Militarism#
+#Fascism#
+Lightning Warfare = 전격전
+#Police State#
+#Nationalism#
+Third Alternative = 제3의 수단
+#Total War#
+Iron Fist = 철권
+Cult of Personality = 개인 숭배
+Gunboat Diplomacy = 포함외교
+Clausewitz's Legacy = 클라우제비츠의 유산
+Autocracy I Complete = 독재 나 완성
+
+Ideology = 이념
+Report as error if you adopt this = 당신이 이걸 완성했다면, 버그니 신고해주세요!
 
 #################### Lines from Techs.json ####################
 
-Drama and Poetry = 드라마와 시
-'What is drama but life with the dull bits cut out.' - Alfred Hitchcock = "드라마는 지루한 부분을 잘라낸 인생일 뿐이다." - 알프레드 히치콕
-
-Advanced Ballistics = 고등 탄도학
-'Our scientific power has outrun our spiritual power, we have guided missiles and misguided men.' - Martin Luther King Jr. = 과학의 힘이 정신의 힘을 뛰어넘었습니다. 우린 유도탄을 만들어내면서도 정작 사람들을 바른길로 유도하지 못하고 있습니다. - 마틴 루서 킹 주니어
-
-Nuclear Fusion = 핵융합
-'The release of atomic energy has not created a new problem. It has readily made more urgent the necessity of solving an existing one.' - Albert Einstein = 핵에너지의 방출로 인하여 새로운 문제가 생긴 것은 아니다. 그저 기존의 문제를 빨리 해결할 필요성이 커졌을 뿐이다. - 알베르트 아인슈타인
-
-Stealth = 스텔스
-'Be extremely subtle, even to the point of formlessness, be extremely mysterious, even to the point of soundlessness. Thereby you can be the director of the opponent' state' - Sun Tzu = 미묘하고도 미묘하여 보이지 않는 경지에 이르며, 신비하고도 신비하여 소리가 없는 경지에 이른다. 그러므로 능히 적의 생사를 맡아 다스리게 되는 것이다. - 손자
-
-Telecommunications = 전기통신
-'The more we elaborate our means of communication, the less we communicate.' - J.B. Priestly = 통신 수단이 발전하면 할수록 의사소통이 줄어든다. - J.B. 프레스틀리
-
+#추가없는듯#
 
 
 #################### Lines from Terrains.json ####################
 
-Desert Hill = 사막 언덕
-
 
 #################### Lines from TileImprovements.json ####################
 
-Farm = 농장
-
-Mine = 광산
-
-Pasture = 목장
-
-Gives a defensive bonus of 50% = 50% 방어력 보너스 부여
-Chateau = 프랑스식 성
-
 Brazilwood Camp = 브라질 소방목 야영지
-
-Polder = 간척지
-
+Caer = 카예
+Chateau = 샤토
+Harjis = 하지
+Kampong Ayer = 물의 마을
 Kasbah = 카스바
+Motte and Bailey = 모트 앤 베일리
+Sacred Grove = 신성한 숲
+Tibetan Monastery = 티베트식 수도원
+Tipi = 티피
 
-Can only be built on Coastal tiles = 해안 타일에만 건설이 가능합니다
-Feitoria = 포르투갈 교역소
-
-Archaeological Dig = 유적 발굴지
-
+Archaeological Dig = 발굴지
+Dry Dock = 드라이 독
 
 #################### Lines from TileResources.json ####################
 
-Sheep = 양
+Amber = 호박석
+Antiquity Site = 사적지
+Cloves = 정향
+Coconut = 코코넛
+Coffee = 커피
+Coral = 산호
+Glass = 유리
+Hardwood = 경목
+Jade = 옥
+Lapis Lazuli = 청금석
+Maize = 옥수수
+Nutmeg = 육두구
+Obsidian = 흑요석
+Olives = 올리브
+Pepper = 후추
+Perfume = 향수
+Rubber = 고무
+Tea = 차
+Tobacco = 담배
 
-Horses = 말
-
-Iron = 철
-
-Coal = 석탄
-
-Aluminum = 알루미늄
-
-Uranium = 우라늄
-
-Gems = 보석
-
-Gold = 금
-
-Silver = 은
-
-Bison = 들소
-
-Citrus = 감귤
-
-Copper = 구리
-
-Cocoa = 코코아
-
-Crab = 게
-
-Truffles = 송로버섯
-
-Salt = 소금
-
-Antiquity Site = 유적지
+Factories = 공장 한도
+Great Work of Art = 걸작 예술품
+Great Work of Music = 걸작 음악
+Great Work of Writing = 걸작 서적
+Level 1 Ideology = Level1 이념
+Level 2 Ideology = Level2 이념
+Trade Route = 무역로 제한
 
 #################### Lines from UnitPromotions.json ####################
 
-Amphibious = 수륙양용
-
-War Canoes = 
-Defense bonus when embarked = 
-
-Heavy Charge = 
-Bonus as Attacker [amount]% = 
-
-Homeland Guardian = 조국 수호자
-
-Desert Warrior = 사막 전사
-+[50]% combat bonus in [Desert] = 
-
-Feared Elephant = 
-
-Mystic Blade = 
-Access to special promotions = 
+Altitude Training = 고산 훈련
+Devout = 독실한
+Dharma = 달마
+Feared Elephant = 코끼리 겁주기
+Heavy Charge = 육중한 돌진
+Homeland Guardian = 향토방위군
+Leadership = 지도력
+Swift Charge = 신속한 돌진
+War Canoes = 전투카누
 
 Ambition = 야망
+Desert Warrior = 사막의 전사
+Heroism = 영웅심
+Invulnerability = 무적
+Mystic Blade = 비전의 보도
+Recruitment = 모집
+Restlessness = 초조감
+Sneak Attack = 기습 공격
 
-Invulnerability = 
-All healing effects doubled = 
+Buffalo Horns I = 버팔로 뿔
+Buffalo Chest II = 버팔로 가슴
+Buffalo Loins III = 버팔로 허리
 
+Gehorsam = 복종
+Disziplin = 규칙
+Fleiss = 일관
+Tapferkeit = 용감
+Zielstrebigkei = 결정
+Härte = 경도
+Pünktlichkeit = 엄격
+Zuverlässigkeit = 신뢰
+Zurückhaltung = 제지
+Pflichtbewusstsein = 사명
 
-Restlessness = 
-1 additional attack per turn = 턴 당 1개의 추가 공격
-
-Spear Throw = 투창
-
-Buffalo Horns I = 
-Buffalo Chest II = 
-Buffalo Loins III = 
-
+Sampy = 우상
+Kelimazala = 부상
+Ramahavaly = 애향
+Manjakatsiroa = 숨기
+Mosasa = 신경
+Rafantaka = 집착
+Rabehaza = 언변
+Ambohimanambola = 지도
+Sehatra = 단계
+Lambamena = 광분
+Razana = 선조
+Masina = 비겁
 
 #################### Lines from Units.json ####################
 
-Missionary = 선교사
+Dalai Lama = 달라이 라마
+Fast Worker = 노동계급
+Hetairoi = 헤타이로이
+Krivis = 크리비스
+Mpiambina = 군종심문관
+Ngangkari = 은강카리
+Pathfinder = 길잡이
+Pioneer = 개척단
+Pittore = 피토레 화가
 
-Archaeologist = 고고학자
-
-Galley = 갤리
-
-Hand-Axe = 손도끼병
-
-Great Admiral = 위대한 제독
-
-Composite Bowman = 합성궁병
-
-Privateer = 사략선
-
-Marine = 해병대
-Defense bonus when embarked = 정박했을 때 방어 보너스
-Amphibious = 수륙양용
-+1 Visibility Range = +1 시야
-
-Helicopter Gunship = 공격 헬기
-No defensive terrain bonuses = 지형 방어 보너스 없음
-Ignores terrain cost = 지형별 이동 비용 무시
-Can move after attacking = 
-Bonus vs [unitType] = [unitType] 상대 보너스
-
-Missile Cruiser = 미사일 순양함
-[amount]% chance to intercept air attacks = 공습을 요격할 확률 [amount]%
-Can attack submarines = 잠수함 공격가능
-
-Jet Fighter = 제트 전투기
-6 tiles in every direction always visible = 모든 방향으로 부터 6타일을 언제나 볼 수 있음
-
-Stealth Bomber = 스텔스 폭격기
-Evasion = 회피
-
-Bazooka = 바주카
-
-Nuclear Submarine = 핵잠수함
-Bonus as Attacker [amount]% = 공격시 전투력 [amount]% 보너스
-Can only attack water = 수상 타일만 공격 가능
-Can enter ice tiles = 얼음 타일로 진입 가능
-Invisible to others = 다른 문명에게 보이지 않음
-
-Mobile SAM = 지대공 미사일
-
-Giant Death Robot = 거대 전투 로봇
-No defensive terrain bonus = 방어 지형 보너스 없음
-
-Siege Tower = 공성탑
-
-Hussar = 후사르
-Penalty vs [unitType] = [unitType]상대시 패널티
-
-Jaguar = 재규어 전사
-Heals [amount] damage if it kills a unit = 유닛을 처치할 시 [amount] 회복
-+33% combat bonus in Forest/Jungle = 숲/정글에서 +33% 전투력 보너스
-
-Pracinha = 프라싱야
-Combat very likely to create Great Generals = 전투 시 위대한 제독 탄생 가능성 높음
-
-Dromon = 드로몬
-Cannot enter ocean tiles = 대양 타일을 항해할 수 없음
-
-Cataphract = 카타프락토이
-
-Quinquereme = 오단노선
-
-African Forest Elephant = 아프리카 숲 코끼리
--10% combat strength for adjacent enemy units = 인접한 적 유닛의 전투력 -10%
-No Defensive Terrain Bonuses = 방어 보너스 없음
-
-Pictish Warrior = 픽트족 전사
-No movement cost to pillage. = 
-
-Sea Beggar = 제고이센
-Unit will heal every turn, even if it performs an action = 무조건 매 턴마다 체력 회복
-
-Mehal Sefari = 메할 세파리
-+30% bonus outside friendly territory = 아군 영토 밖에서 +30% 전투력 보너스
-
-Battering Ram = 공성추
-Limited Visibility = 제한된 시야
-
-Horse Archer = 기마궁수
-
-Kris Swordsman = 크리스 검사
-
-Atlatlist = 아틀라틀 투척병
-
+Akyat Cannon = 아크야트 대포
+Apedemaks Bow = 사자신의 활
+Baghlah = 박을라
+Ballista Elephant = 발리스타 코끼리
 Berber Cavalry = 베르베르 기병대
-+25% bonus outside friendly territory = 아군영토 밖에서 +25% 전투력 보너스
-
+Black Arquebusier = 검은 화승총 병단
+Buffalo Hunter = 버팔로 사냥꾼
+Comanche Riders = 코만치 기병
+Combat Engineer = 전투 공병대
+Crusader = 십자군
+Dhow = 다우
+Fenian = 페니언 형제단
+Force Publique = 식민지 주둔군
+Gadrauht = 가드라우하트
+Gallowglass = 용병 전사
+Gaucho = 가우초
+Great Galleass = 대형 갈레아스
+Grenadine Cavalry = 그레다닌 기병대
+Heavy Chariot = 중전차
+Impi = 임피
+Koa = 코아
+Konnitsa = 불가르 기병대
+Kris Swordsman = 크리스 검사
+Kuva-yi Milliye = 쿠바이 밀리예
+Landwehr = 란트베어
+Laputtu = 라푸투
+Longship = 롱쉽
+Maccabee = 마카비
+Mamluk = 맘루크
+Marathi Rider = 마라티 라이더
+Matato'a = 마타또아
+Nau = 나우
+Ngao Mbeba = 은가오 음베바
+Noble Swordsman = 귀족 검사
+Phalanx = 팔랑크스
+Pedite = 페디테
+Pestininkas = 해충
+Pracinha = 프라싱야
+Qianlong Cavalry = 황제 친위대
+Ranchero = 목장주
+Rocket Corps = 로켓 군단
+Saethwyr = 궁수요
+Sarissophoroi = 사리소포로이
+Seaxman = 시스맨
+Shona Warrior = 쇼나 전사
+Siege Tower = 공성탑
+Sissi = 시씨
+Ski Infantry = 스키 보병
+Sparapet = 스파라펫
+Square Sail Ship = 사각 범선
+Swiss Guard = 스위스 근위대
+Tachanka = 타찬카
+Ulan = 울란
+Vanator = 사냥꾼 부대
+Viet Cong = 베트콩
+Voortrekker = 선구자
 Winged Hussar = 날개달린 후사르
 
-Nau = 나우
-Can undertake a trade mission with City-State, giving a large sum of gold and [amount] Influence = 도시국가와의 무역 임무 가능, 많은 양의 금과 [amount]만큼의 영향력을 받음
-May withdraw before melee = 근접 전투 전에 도망갈 가능성 있음
-
-Pathfinder = 길잡이
-
-Comanche Riders = 코만치 기병
-
-Hakkapeliitta = 하카펠리타
-
-Carolean = 캐롤리언
-
-Merchant of Venice = 베니스의 상인
-Can build improvement: Customs house = 세관 시설을 건설할 수 없음
-
-Great Galleass = 대형 갈레아스
-
-Impi = 임피
-
+Airship = 비행선
+Anti-Tank Rifle = 대전차포
+Archaeologist = 고고학자
+Bazooka = 바주카포
+Caravan = 무역상
+Cargo Ship = 화물선
+Future Soldier = 미래보병
+Great Admiral = 위대한 제독
+Great Musician = 위대한 음악가
+Great Writer = 위대한 작가
+Hand-Axe = 도끼투척병


### PR DESCRIPTION
After fixing the bugs, I created a minimal translation.

It is based on the Encyclopedia of Civilization. 

Most of the names and descriptions of in-game mechanics have been translated. Additional elements such as work slots or trade routes have not been translated.

Given my skills, the quality of the translation was not good, and there was a lot of transliteration and paraphrase, but since there was none, I just spent my time. 

Also, sentences that overlap with vanilla, which also caused bugs. I checked in-game and deleted everything that was translated even if it wasn't there.

Lastly, purely explanatory sentences, city names, diplomatic lines, etc. were not translated.