### PR TITLE
Nations update

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -988,6 +988,7 @@
         "replaces": "Caravansary",
         "cost": 100,
         "hurryCostModifier": 25,
+        "gold": 2,
         "uniques": [
             "[+2 Gold] from [Land Trade Route (Gold)] tiles [in this city]",
             "[+1 Gold] per [3] population [in this city]"
@@ -1492,7 +1493,7 @@
         "hurryCostModifier": 25,
         "percentStatBonus": {"gold": 25},
         "uniques": [
-            "Gain [20] [Gold] <(modified by game speed)> <upon gaining a [Great Person] unit>", // should be on expending... give me some time to work on it
+            "Gain [30] [Gold] <(modified by game speed)> <upon gaining a [Great Person] unit>", // should be on expending... give me some time to work on it
             "[+1 Gold] from [Land Trade Route (Gold)] tiles [in this city]",
             "[+1 Gold] from [Sea Trade Route (Gold)] tiles [in this city]"
         ],
@@ -2155,8 +2156,7 @@
             "New [Military] units start with [15] Experience [in this city]",
             "Destroyed when the city is captured",
             "[+1 Food, +1 Culture, +1 Production] from [Marsh] tiles [in this city]",
-            "[+1 Culture] from [Jungle] tiles [in this city]",
-            "All newly-trained [Melee] units [in this city] receive the [Woodsman] promotion"
+            "[+1 Culture] from [Jungle] tiles [in this city]"
         ],
         "requiredTech": "Metal Casting"
     },

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -1035,6 +1035,7 @@
             "[+1 Production, +1 Gold] from [Cattle] tiles [in this city]",
             "[+1 Production, +1 Gold] from [Horses] tiles [in this city]",
             "[+1 Production, +1 Gold] from [Sheep] tiles [in this city]",
+            "[+1 Food, +1 Gold] from [Maize] tiles [in this city]",
             "New [Mounted] units start with [15] Experience [in this city]"
         ],
         "requiredTech": "Horseback Riding"

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -1017,7 +1017,8 @@
             "[+15]% Production when constructing [Mounted] units [in this city]",
             "[+1 Production, +1 Food] from [Cattle] tiles [in this city]",
             "[+1 Production, +1 Food] from [Horses] tiles [in this city]",
-            "[+1 Production, +1 Food] from [Sheep] tiles [in this city]"
+            "[+1 Production, +1 Food] from [Sheep] tiles [in this city]",
+            "[+1 Production, +1 Food] from [Maize] tiles [in this city]"
         ],
         "requiredTech": "Horseback Riding"
     },
@@ -1112,6 +1113,7 @@
         "name": "Mead Hall",
         "replaces": "Colosseum",
         "uniqueTo": "Franks",
+        "cost": 50,
         "happiness": 3,
         "culture": 1,
         "hurryCostModifier": 25,

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -461,7 +461,7 @@
         "culture": 2,
         "cost": 20,
         "hurryCostModifier": 40,
-        "maintenance": 1,
+        "maintenance": 0,
         "requiredTech": "Pottery",
         "uniques": ["Destroyed when the city is captured"]
     },

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -510,6 +510,7 @@
             "[+1 Food] from [Bison] tiles [in this city]",
             "[+1 Food] from [Bananas] tiles [in this city]",
             "[+1 Food] from [Wheat] tiles [in this city]",
+            "[+1 Food] from [Maize] tiles [in this city]",
             "[+2 Food, +2 Culture] <with [3] to [6] neighboring [Coast] tiles>"
         ],
         "requiredTech": "Sailing"
@@ -1002,7 +1003,8 @@
             "[+15]% Production when constructing [Mounted] units [in this city]",
             "[+1 Production] from [Cattle] tiles [in this city]",
             "[+1 Production] from [Horses] tiles [in this city]",
-            "[+1 Production] from [Sheep] tiles [in this city]"
+            "[+1 Production] from [Sheep] tiles [in this city]",
+            "[+1 Food] from [Maize] tiles [in this city]"
         ],
         "requiredTech": "Horseback Riding"
     },

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -988,7 +988,6 @@
         "replaces": "Caravansary",
         "cost": 100,
         "hurryCostModifier": 25,
-        "gold": 2,
         "uniques": [
             "[+2 Gold] from [Land Trade Route (Gold)] tiles [in this city]",
             "[+1 Gold] per [3] population [in this city]"

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -493,7 +493,7 @@
             "[+1 Food] from [Bison] tiles [in this city]",
             "[+1 Food] from [Bananas] tiles [in this city]",
             "[+1 Food, +1 Gold] from [Wheat] tiles [in this city]",
-            "[+1 Gold] from [Cattle] tiles [in this city]"
+            "[+1 Food, +1 Gold] from [Maize] tiles [in this city]"
         ],
         "requiredTech": "Pottery"
     },
@@ -1004,8 +1004,7 @@
             "[+15]% Production when constructing [Mounted] units [in this city]",
             "[+1 Production] from [Cattle] tiles [in this city]",
             "[+1 Production] from [Horses] tiles [in this city]",
-            "[+1 Production] from [Sheep] tiles [in this city]",
-            "[+1 Food] from [Maize] tiles [in this city]"
+            "[+1 Production] from [Sheep] tiles [in this city]"
         ],
         "requiredTech": "Horseback Riding"
     },
@@ -1020,8 +1019,7 @@
             "[+15]% Production when constructing [Mounted] units [in this city]",
             "[+1 Production, +1 Food] from [Cattle] tiles [in this city]",
             "[+1 Production, +1 Food] from [Horses] tiles [in this city]",
-            "[+1 Production, +1 Food] from [Sheep] tiles [in this city]",
-            "[+1 Production, +1 Food] from [Maize] tiles [in this city]"
+            "[+1 Production, +1 Food] from [Sheep] tiles [in this city]"
         ],
         "requiredTech": "Horseback Riding"
     },
@@ -1036,7 +1034,6 @@
             "[+1 Production, +1 Gold] from [Cattle] tiles [in this city]",
             "[+1 Production, +1 Gold] from [Horses] tiles [in this city]",
             "[+1 Production, +1 Gold] from [Sheep] tiles [in this city]",
-            "[+1 Food, +1 Gold] from [Maize] tiles [in this city]",
             "New [Mounted] units start with [15] Experience [in this city]"
         ],
         "requiredTech": "Horseback Riding"
@@ -1110,6 +1107,7 @@
         "name": "Colosseum",
         "maintenance": 1,
         "happiness": 2,
+        "cost": 100,
         "hurryCostModifier": 25,
         "requiredTech": "Construction"
     },
@@ -1117,7 +1115,7 @@
         "name": "Mead Hall",
         "replaces": "Colosseum",
         "uniqueTo": "Franks",
-        "cost": 50,
+        "cost": 75,
         "happiness": 3,
         "culture": 1,
         "hurryCostModifier": 25,
@@ -1493,7 +1491,7 @@
         "hurryCostModifier": 25,
         "percentStatBonus": {"gold": 25},
         "uniques": [
-            "Gain [30] [Gold] <(modified by game speed)> <upon gaining a [Great Person] unit>", // should be on expending... give me some time to work on it
+            "Gain [20] [Gold] <upon gaining a [Great Person] unit>", // should be on expending... give me some time to work on it
             "[+1 Gold] from [Land Trade Route (Gold)] tiles [in this city]",
             "[+1 Gold] from [Sea Trade Route (Gold)] tiles [in this city]"
         ],

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -493,7 +493,7 @@
             "[+1 Food] from [Bison] tiles [in this city]",
             "[+1 Food] from [Bananas] tiles [in this city]",
             "[+1 Food, +1 Gold] from [Wheat] tiles [in this city]",
-            "[+1 Food, +1 Gold] from [Maize] tiles [in this city]"
+            "[+1 Gold] from [Cattle] tiles [in this city]"
         ],
         "requiredTech": "Pottery"
     },
@@ -510,7 +510,6 @@
             "[+1 Food] from [Bison] tiles [in this city]",
             "[+1 Food] from [Bananas] tiles [in this city]",
             "[+1 Food] from [Wheat] tiles [in this city]",
-            "[+1 Food] from [Maize] tiles [in this city]",
             "[+2 Food, +2 Culture] <with [3] to [6] neighboring [Coast] tiles>"
         ],
         "requiredTech": "Sailing"

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -1783,8 +1783,10 @@
         "uniques": [
             "[-100]% maintenance costs <for [Mounted] units>",
             "[-100]% maintenance costs <for [Armor] units>",
+            "[-100]% maintenance costs <for [Bomber] units>",
             "[Mounted] units gain the [Volley] promotion",
-            "[Armor] units gain the [Volley] promotion"
+            "[Armor] units gain the [Volley] promotion",
+            "[Bomber] units gain the [Volley] promotion"
             //"[+100]% Production when constructing [Stable] buildings [in all cities]",
             //"[+1 Gold] from every [Stable]"
         ],

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -2788,7 +2788,8 @@
         "uniqueName": "Nobel Prize",
         "uniques": [
             "[+20]% Great Person generation [in all cities]",
-            "Gain [100] Influence with a [Great Person] gift to a City-State"
+            "Gain [100] Influence with a [Great Person] gift to a City-State",
+            "Gain [200] [Gold] with a [Great Person] gift to a City-State"
         ],
         "cities": [
             "Stockholm","Sigtuna","Helsinki","Birka","Uppsala","Turku","Linköping","Lund","Espoo","Malmö",
@@ -3040,7 +3041,8 @@
         "uniqueName": "Tam Giao",
         "uniques": [
             "[+2 Food, +1 Production] from every [Marsh]",
-            "[+1 Faith] from every [Jungle]"
+            "[+1 Faith] from every [Jungle]",
+            "[Land] units gain the [Vietnamese Walking] promotion"
         ],
         "cities": [
             "Hà Noi","Thành Pho Ho Chí Minh","Hai Phòng","Thành Pho Hue","Can Tho","Dà Nang","Biên Hòa","Phan Rang","Quang Ngãi","Quang Ninh",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -2305,7 +2305,7 @@
         "innerColor": [234,201,52],
         "uniqueName": "Skillful Traders",
         "uniques": [
-            "Gain [50] [Gold] <(modified by game speed)> <upon founding a city> <after discovering [Optics]>",
+            "Gain [75] [Gold] <(modified by game speed)> <upon founding a city> <after discovering [Optics]>",
             "[+1] population [in this city] <upon founding a city> <after discovering [Optics]>",
             "Free [Square Sail Ship] appears <upon discovering [Sailing] technology>"
         ],

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -1820,7 +1820,7 @@
         "uniques": [
             "[Land] units gain the [Dharma] promotion <hidden from users>",
             "[Water] units gain the [Dharma] promotion <hidden from users>",
-            "Comment [Non-Air Units receive a -15% Combat Penalty when attacking, and a +15% Combat Bonus when defending]"
+            "Comment [Non-Air Units receive a -10% Combat Penalty when attacking, and a +10% Combat Bonus when defending]"
         ],
         "cities": [
             "Pataliputra","Sarnath","Ujjain","Mathura","Indraprastha","Suvarnagiri","Tamralipti","Varanasi","Lumbini","Toshali",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -1916,7 +1916,7 @@
             "[+30]% Strength <vs [City-States]>",
             "[+1] Movement <for [Mounted] units>",
             "[+1] Movement <for [Armor] units>",
-            "Double quantity of [Horses] produced",
+            "Double quantity of [Horses] produced <after discovering [Chivalry]>",
             "[+1 Food] from every [Horses] <after discovering [Chivalry]>"
         ],
         "cities": [

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -2402,7 +2402,7 @@
         "innerColor": [8,25,115],
         "uniqueName": "Mare Clausum",
         "uniques": [
-            "[+3 Gold] from every [Luxury resource]",
+            "[+3 Gold] from every [Trade Route]",
             "[+33]% Production when constructing [Caravan] units [in all cities]",
             "[+33]% Production when constructing [Cargo Ship] units [in all cities]"
         ],

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -826,7 +826,8 @@
             "[+1 Happiness] from every [Police Station]",
             "[+1 Happiness] from every [Constabulary]",
             "[+100]% Production when constructing [Police Station] buildings [in all cities]",
-            "[+100]% Production when constructing [Constabulary] buildings [in all cities]"
+            "[+100]% Production when constructing [Constabulary] buildings [in all cities]",
+            "Gain an extra spy <upon entering the [Renaissance]>"
         ],
         "cities": [
             "London","York","Nottingham","Hastings","Canterbury","Coventry","Warwick","Newcastle","Oxford","Liverpool",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -2148,7 +2148,7 @@
         "outerColor": [193,159,86],
         "innerColor": [0,0,0],
         "uniqueName": "Ta-Seti",
-        "uniques": ["Free [Apedemaks Bow] appears <upon discovering [Agriculture] technology>"],
+        "uniques": ["Free [Apedemaks Bow] appears"],
         "cities": [
             "Meroe","Napata","Kerma","Nuri","Kawa","Sadeinga","Iken","Buhen","Faras","Pademe",
             "Shaat","Heh","Dengeil","Miam","Tombos","Kurgus","Debba","Bugdumbush","Ukma","Defeia",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -2148,7 +2148,7 @@
         "outerColor": [193,159,86],
         "innerColor": [0,0,0],
         "uniqueName": "Ta-Seti",
-        "uniques": ["Free [Apedemaks Bow] appears <upon discovering [Pottery] technology>"],
+        "uniques": ["Free [Apedemaks Bow] appears <upon discovering [Agriculture] technology>"],
         "cities": [
             "Meroe","Napata","Kerma","Nuri","Kawa","Sadeinga","Iken","Buhen","Faras","Pademe",
             "Shaat","Heh","Dengeil","Miam","Tombos","Kurgus","Debba","Bugdumbush","Ukma","Defeia",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -1078,7 +1078,10 @@
         "outerColor": [29, 26, 26],
         "innerColor": [181, 214, 207],
         "uniqueName": "Drauhtinon",
-        "uniques": ["[+1] Movement <for [Melee] units>"],
+        "uniques": [
+            "[+1] Movement <for [Sword] units>",
+            "[+1] Movement <for [Gunpowder] units>"
+        ],
         "cities": [
             "Arheimar","Aujum","Potaissa","Apulon","Tyras","Sarmizegetusa","Argidava","Olite","Tolosa","Olbia",
             "Reccopolis","Toletum","Pityus","Burdigala","Gerunda","Aiadava","Thessalonica","Victoriacum","Carnuntum","Sirmium",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -2473,7 +2473,9 @@
         "uniqueName": "Nihil Sine Deo",
         "uniques": [
             "[+10]% Strength <for [Military] units> <vs [Wounded] units>",
-            "[+25]% [Culture] [in all cities] <during a Golden Age>"
+            "[+25]% [Culture] [in all cities] <during a Golden Age>",
+            "Instantly gain [100] [GoldenAgePoints] <upon conquering a city>"
+            //need new uniq for liberating cities too
         ],
         "cities": [
             "Bucharest","Craiova","Iasi","Constanta","Botosani","Braila","Ploiesti","Galati","Bacau","Pitesti",

--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -708,6 +708,7 @@
         "uniques": [
             "[+1 Production] <after discovering [Navigation]>",
             "[+1 Culture] <after discovering [Flight]>",
+            "Must be next to [Land]",
             "Cannot be built on [resource] tiles",
             "Pillaging this improvement yields approximately [+20 Gold]"
         ]

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -892,6 +892,14 @@
         "name": "Can Enter Rival Territory", //only for Crusader and subsequent upgrades
         "uniques": ["May enter foreign tiles without open borders"]
     },
+    {
+        "name": "Range Defence", //only for Ngao Mbeba and subsequent upgrades
+        "uniques": ["[+100]% Strength <when defending> <vs [Ranged] units>"]
+    },
+    {
+        "name": "May Not Melee Attack", //only for Ngao Mbeba and subsequent upgrades
+        "uniques": ["Cannot attack"]
+    },
     // Section Kris Swordsmen
     {
         "name": "Mystic Blade",

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -707,7 +707,7 @@
         ]
     },
     {
-        "name": "[Sipahi] ability",
+        "name": "No movement cost to pillage",
         "uniques": [
             "No movement cost to pillage"
         ]
@@ -885,8 +885,12 @@
         "uniques": ["Can move after attacking"]
     },
     {
-        "name": "Foreign Land Bonus", //only for Pracinha and subsequent upgrades
+        "name": "Foreign Land Bonus", //only for Pracinha and Crusader and subsequent upgrades
         "uniques": ["[+20]% Strength <when fighting in [Foreign Land] tiles>"]
+    },
+    {
+        "name": "Can Enter Rival Territory", //only for Crusader and subsequent upgrades
+        "uniques": ["May enter foreign tiles without open borders"]
     },
     // Section Kris Swordsmen
     {

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -850,7 +850,10 @@
             "Earn [100]% of killed [Military] unit's [Strength] as [GoldenAgePoints]"
         ]
     },
-
+    {
+        "name": "Extra Sight",
+        "uniques": ["[+1] Sight"]
+    },
     // Section Kris Swordsmen
     {
         "name": "Mystic Blade",

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -854,6 +854,20 @@
         "name": "Extra Sight",
         "uniques": ["[+1] Sight"]
     },
+    {
+        "name": "Extra Movement",
+        "uniques": ["[+1] Movement"]
+    },
+    {
+        "name": "Forest native",
+        "uniques": [
+            "[+33]% Strength <when attacking>",
+            "[+50]% Strength <when fighting in [Forest] tiles>"]
+    },
+    {
+        "name": "Heals 25 Damage If Kill a Unit",
+        "uniques": ["[This Unit] heals [25] HP <upon defeating a [All] unit>"]
+    },
     // Section Kris Swordsmen
     {
         "name": "Mystic Blade",

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -790,6 +790,13 @@
             "[+50]% Strength <when attacking>"
         ]
     },
+    //need new uniq for "enemy Units will retreat if they receive more damage than this Unit; this Unit deals +50% damage to defenders incapable of retreat"
+    {
+        "name": "Bonus For Attacking",
+        "uniques": [
+            "[+50]% Strength <when attacking>"
+        ]
+    },
     {
         "name": "Sauna",
         "uniques": [
@@ -899,6 +906,15 @@
     {
         "name": "May Not Melee Attack", //only for Ngao Mbeba and subsequent upgrades
         "uniques": ["Cannot attack"]
+    },
+    {
+        "name": "Vietnamese Walking",
+        "uniques": [
+            "Double movement in [Marsh]",
+            "Double movement in [Jungle]",
+            "[+30]% Strength <when fighting in [Marsh] tiles>",
+            "[+15]% Strength <when fighting in [Jungle] tiles>"
+        ]
     },
     // Section Kris Swordsmen
     {

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -719,7 +719,7 @@
         ]
     },
     {
-        "name": "[Hussar] ability",
+        "name": "Enhanced Flank Attack",
         "uniques": [
             "[+50]% to Flank Attack bonuses"
         ]

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -868,6 +868,26 @@
         "name": "Heals 25 Damage If Kill a Unit",
         "uniques": ["[This Unit] heals [25] HP <upon defeating a [All] unit>"]
     },
+    {
+        "name": "Overseer", // only for Laputtu and subsequent upgrades
+        "uniques": ["Transfer Movement to [Civilian]"]
+    },
+    {
+        "name": "Heals Completely Upon Killing", //only for Voortrekker and subsequent upgrades
+        "uniques": ["Heals [100] damage if it kills a unit"]
+    },
+    {
+        "name": "Strong Defence", //only for Voortrekker and subsequent upgrades
+        "uniques": ["[+25]% Strength <when defending>"]
+    },
+    {
+        "name": "Can Move After Attacking", //only for Pracinha and subsequent upgrades
+        "uniques": ["Can move after attacking"]
+    },
+    {
+        "name": "Foreign Land Bonus", //only for Pracinha and subsequent upgrades
+        "uniques": ["[+20]% Strength <when fighting in [Foreign Land] tiles>"]
+    },
     // Section Kris Swordsmen
     {
         "name": "Mystic Blade",

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -775,7 +775,7 @@
     {
         "name": "Homeland Guardian",
         "uniques": [
-            "[+20]% Strength <when fighting in [Friendly Land] tiles>"
+            "[+25]% Strength <when fighting in [Friendly Land] tiles>"
         ]
     },
     {

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -859,7 +859,7 @@
         "uniques": ["[+1] Movement"]
     },
     {
-        "name": "Forest native",
+        "name": "Forest Native",
         "uniques": [
             "[+33]% Strength <when attacking>",
             "[+50]% Strength <when fighting in [Forest] tiles>"]

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -818,10 +818,7 @@
         "requiredTech": "Iron Working",
         "upgradesTo": "Longswordsman",
         "obsoleteTech": "Steel",
-        "uniques": [
-            "[+100]% Strength <when defending> <vs [Ranged] units>",
-            "Cannot attack"
-        ],
+        "promotions": ["Range Defence", "May Not Melee Attack"],
         "hurryCostModifier": 20,
         "attackSound": "metalhit"
     },
@@ -3026,7 +3023,7 @@
             "Great Person - [Faith]",
             "Uncapturable",
             "Unbuildable",
-            "Only available <when religion is enabled>",
+            "Only available <when religion is enabled>"
         ],
         "movement": 4
     },

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1727,6 +1727,7 @@
         "requiredTech": "Navigation",
         "obsoleteTech": "Electronics",
         "upgradesTo": "Battleship",
+        "promotions": ["Extra Sight"],
         "hurryCostModifier": 20,
         "attackSound": "cannon"
     },

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -593,12 +593,12 @@
         "cost": 120,
         "requiredTech": "Horseback Riding",
         "upgradesTo": "Knight",
+        "promotions": ["Leadership"],
         "uniques": [
             "Consumes [2] [Horses]",
             "Can move after attacking",
             "No defensive terrain bonus",
-            "[-33]% Strength <vs cities> <when attacking>",
-            "[+15]% Strength bonus for [Military] units within [2] tiles"
+            "[-33]% Strength <vs cities> <when attacking>"
         ],
         "hurryCostModifier": 20,
         "attackSound": "horse"
@@ -1113,12 +1113,11 @@
         "obsoleteTech": "Military Science",
         "upgradesTo": "Cavalry",
         "requiredResource": "Horses",
+        "promotions": ["Swift Charge"],
         "uniques": [
             "Can move after attacking",
             "No defensive terrain bonus",
-            "[-33]% Strength <vs cities> <when attacking>",
-            "[+50]% Strength <vs [Sword] units>",
-            "[+25]% Strength <vs [Gunpowder] units>"
+            "[-33]% Strength <vs cities> <when attacking>"
         ],
         "attackSound": "horse"
     },
@@ -1408,10 +1407,7 @@
         "strength": 20,
         "cost": 120,
         "requiredTech": "Steel",
-        "uniques": [
-            "[+33]% Strength <when attacking>",
-            "[+50]% Strength <when fighting in [Forest] tiles>"
-        ],
+        "promotions": ["Forest native"],
         "upgradesTo": "Rifleman",
         "obsoleteTech": "Rifling",
         "attackSound": "metalhit"
@@ -1427,9 +1423,7 @@
         "requiredTech": "Steel",
         "upgradesTo": "Musketman",
         "obsoleteTech": "Gunpowder",
-        "uniques" :[
-            "[This Unit] heals [25] HP <upon defeating a [All] unit>"
-        ],
+        "promotions": ["Heals 25 Damage If Kill a Unit"],
         "attackSound": "metalhit"
     },
     {
@@ -1723,7 +1717,6 @@
         "rangedStrength": 30,
         "cost": 185,
         "requiredResource": "Iron",
-        "uniques": ["[+1] Sight"],
         "requiredTech": "Navigation",
         "obsoleteTech": "Electronics",
         "upgradesTo": "Battleship",
@@ -1768,7 +1761,7 @@
             "[+33]% Strength <vs [Armored] units>",
             "[+33]% Strength <vs [Mounted] units>"
         ],
-        "promotions": ["Heavy Charge"],
+        "promotions": ["Heavy Charge", "Extra Sight", "Extra Movement"],
         "upgradesTo": "Anti-Tank Rifle",
         "obsoleteTech": "Railroads",
         "attackSound": "horse"

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -634,7 +634,7 @@
         "requiredTech": "Horseback Riding",
         "upgradesTo": "Knight",
         "obsoleteTech": "Chivalry",
-        "promotions": ["Great Generals II"],
+        "promotions": ["Great Generals II","Heavy Charge"],
         "uniques": [
             "Can move after attacking",
             "No defensive terrain bonus",
@@ -1435,7 +1435,7 @@
         "strength": 21,
         "cost": 120,
         "requiredTech": "Steel",
-        "upgradesTo": "Musketman",
+        "upgradesTo": "Rifleman",
         "obsoleteTech": "Gunpowder",
         "requiredResource": "Iron",
         "promotions": ["Shock I", "Great Generals II"],
@@ -1451,9 +1451,8 @@
         "strength": 17,
         "cost": 105,
         "requiredTech": "Theology",
+        "promotions": ["Foreign Land Bonus", "Can Enter Rival Territory"],
         "uniques": [
-            "May enter foreign tiles without open borders",
-            "[+20]% Strength <when fighting in [Foreign Land] tiles>",
             "Earn [200]% of killed [Military] unit's [Strength] as [Faith]"
         ],
         "upgradesTo": "Musketman",
@@ -1801,7 +1800,7 @@
             "[+33]% Strength <vs [Mounted] units>",
             "[+1] Sight"
         ],
-        "promotions": ["[Sipahi] ability"],
+        "promotions": ["No movement cost to pillage"],
         "upgradesTo": "Anti-Tank Rifle",
         "obsoleteTech": "Railroads",
         "attackSound": "horse"
@@ -2424,16 +2423,15 @@
         "replaces": "Machine Gun",
         "uniqueTo": "Finland",
         "unitType": "Ranged Gunpowder",
-        "range": 1,
+        "range": 2,
         "movement": 2,
         "strength": 50,
         "rangedStrength": 60,
         "cost": 350,
         "requiredTech": "Ballistics",
-        "promotions": ["Ignore terrain cost"],
+        "promotions": ["Ignore terrain cost", "Extra Movement", "No movement cost to pillage"],
         "uniques": [
             "[+25]% Strength <vs [Armored] units>",
-            "No movement cost to pillage",
             "[+33]% Strength <vs [Gunpowder] units>"
         ],
         "upgradesTo": "Bazooka",

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1635,11 +1635,11 @@
         "replaces": "Musketman",
         "uniqueTo": "Sweden",
         "unitType": "Gunpowder",
-        "movement": 3,
+        "movement": 2,
         "strength": 24,
         "cost": 150,
         "requiredTech": "Gunpowder",
-        "promotions": ["March"],
+        "promotions": ["March", "Extra Movement"],
         "upgradesTo": "Rifleman",
         "obsoleteTech": "Rifling",
         "attackSound": "shot"
@@ -2279,7 +2279,8 @@
         "strength": 47,
         "cost": 330,
         "requiredTech": "Replaceable Parts",
-        "uniques": ["[+50]% Strength <when attacking>"],
+        "promotion": ["Extra Movement", "Bonus For Attacking"],
+        "uniques": ["[This Unit] upgrades for free"],
         "upgradesTo": "Infantry",
         "obsoleteTech": "Electronics",
         "attackSound": "shot"
@@ -2373,7 +2374,8 @@
         "strength": 70,
         "cost": 350,
         "requiredTech": "Electronics",
-        "uniques": ["Can pass through impassable tiles"],
+        //"uniques": ["Can pass through impassable tiles"],
+        "uniques": ["[+25]% Strength <vs [Gunpowder] units>"],
         "upgradesTo": "Mechanized Infantry",
         "obsoleteTech": "Mobile Tactics",
         "attackSound": "shot"

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -3077,7 +3077,7 @@
             "Unbuildable",
             "Uncapturable"
         ],
-        "movement": 4
+        "movement": 5
     },
     {
         "name": "Great Admiral",

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -3088,7 +3088,7 @@
             "Unbuildable",
             "Uncapturable"
         ],
-        "movement": 5
+        "movement": 7
     },
     {
         "name": "Great Admiral",

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -348,6 +348,7 @@
         "strength": 10,
         "cost": 38,
         "requiredTech": "Sailing",
+        "promotions": ["Extra Sight", "Supply"],
         "uniques": [
             "Can move after attacking",
             "[-33]% Strength <vs cities> <when attacking>"

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -696,7 +696,8 @@
         "promotions": ["Cover I", "Extra Sight"],
         "uniques": [
             "[+200]% Strength <vs cities> <when attacking>",
-            "No defensive terrain bonus"
+            "No defensive terrain bonus",
+            "Can only attack [City] units"
         ],
         "hurryCostModifier": 20,
         "attackSound": "metalhit"

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -559,9 +559,9 @@
         "requiredTech": "Mining",
         "obsoleteTech": "Civil Service",
         "upgradesTo": "Pikeman",
+        "promotions": ["Enhanced Flank Attack"],
         "uniques": [
-            "[+50]% Strength <vs [Mounted] units>",
-            "[+50]% to Flank Attack bonuses"
+            "[+50]% Strength <vs [Mounted] units>"
         ],
         "attackSound": "metalhit"
     },
@@ -1868,12 +1868,13 @@
         "uniqueTo": "Romania",
         "replaces": "Gatling Gun",
         "unitType": "Ranged Gunpowder",
-        "range": 2,
+        "range": 1,
         "movement": 2,
         "strength": 31,
         "rangedStrength": 31,
         "cost": 225,
         "requiredTech": "Industrialization",
+        "promotions": ["Extended Range"],
         "upgradesTo": "Machine Gun",
         "obsoleteTech": "Ballistics",
         "attackSound": "machinegun"
@@ -1960,8 +1961,7 @@
         "movement": 3,
         "strength": 34,
         "cost": 225,
-        "promotions": ["Blitz","Quick Study"],
-        "uniques": ["Transfer Movement to [All]"],
+        "promotions": ["Blitz","Quick Study", "Extra Movement"],
         "requiredTech": "Military Science",
         "obsoleteTech": "Replaceable Parts",
         "upgradesTo": "Great War Infantry",
@@ -2018,7 +2018,7 @@
             "[-33]% Strength <vs cities> <when attacking>",
             "[+1] Sight"
         ],
-        "promotions": ["[Hussar] ability"],
+        "promotions": ["Enhanced Flank Attack"],
         "attackSound": "horse"
     },
     {
@@ -2093,6 +2093,7 @@
         "obsoleteTech": "Combustion",
         "requiredResource": "Horses",
         "upgradesTo": "Landship",
+        "promotions": ["Extra Movement"],
         "uniques": [
             "Can move after attacking",
             "No defensive terrain bonus",

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -691,11 +691,10 @@
         "requiredTech": "Mathematics",
         "obsoleteTech": "Physics",
         "upgradesTo": "Trebuchet",
-        "promotions": ["Cover I"],
+        "promotions": ["Cover I", "Extra Sight"],
         "uniques": [
             "[+200]% Strength <vs cities> <when attacking>",
-            "No defensive terrain bonus",
-            "[-1] Sight"
+            "No defensive terrain bonus"
         ],
         "hurryCostModifier": 20,
         "attackSound": "metalhit"

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1794,10 +1794,12 @@
             "No defensive terrain bonus",
             "[-33]% Strength <vs cities> <when attacking>",
             "[+33]% Strength <vs [Armored] units>",
-            "[+33]% Strength <vs [Mounted] units>",
-            "[+1] Sight"
+            "[+33]% Strength <vs [Mounted] units>"
         ],
-        "promotions": ["No movement cost to pillage"],
+        "promotions": [
+            "No movement cost to pillage",
+            "Extra Sight"
+        ],
         "upgradesTo": "Anti-Tank Rifle",
         "obsoleteTech": "Railroads",
         "attackSound": "horse"
@@ -2259,7 +2261,11 @@
         "requiredTech": "Replaceable Parts",
         "obsoleteTech": "Electronics",
         "upgradesTo": "Infantry",
-        "promotions": ["[Norwegian Ski Infantry] ability"],
+        "promotions": [
+            "Drill I",
+            "Drill II",
+            "[Norwegian Ski Infantry] ability"
+        ],
         "attackSound": "shot"
     },
     {

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -497,6 +497,7 @@
         "obsoleteTech": "Civil Service",
         "upgradesTo": "Pikeman",
         "uniques": ["[+50]% Strength <vs [Mounted] units>"],
+        "promotions": ["Overseer"],
         "attackSound": "metalhit"
     },
     {
@@ -2231,11 +2232,8 @@
         "strength": 50,
         "cost": 300,
         "requiredTech": "Replaceable Parts",
-        "uniques": [
-            "Heals [100] damage if it kills a unit",
-            "[+25]% Strength <when defending>",
-            "Can build [Farm] improvements on tiles"
-        ],
+        "uniques": ["Can build [Farm] improvements on tiles"],
+        "promotions": ["Heals Completely Upon Killing","Strong Defence"],
         "upgradesTo": "Infantry",
         "obsoleteTech": "Electronics",
         "attackSound": "shot"
@@ -2357,10 +2355,7 @@
         "strength": 80,
         "cost": 410,
         "requiredTech": "Electronics",
-        "uniques": [
-            "[+20]% Strength <when fighting in [Foreign Land] tiles>",
-            "Can move after attacking"
-        ],
+        "promotions": ["Can move after attacking", "Foreign Land Bonus"],
         "upgradesTo": "Mechanized Infantry",
         "obsoleteTech": "Mobile Tactics",
         "attackSound": "shot"

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1407,7 +1407,7 @@
         "strength": 20,
         "cost": 120,
         "requiredTech": "Steel",
-        "promotions": ["Forest native"],
+        "promotions": ["Forest Native"],
         "upgradesTo": "Rifleman",
         "obsoleteTech": "Rifling",
         "attackSound": "metalhit"


### PR DESCRIPTION
I compared Rekmod with the PC version lekmod 33.7 and found that many units have promotions instead uniqueness, that keeps after upgrade. 
Some uniques reimplemented.
Changes by nation:
- England
- Goths
- Ayybids
- Armenia
- Assyria
- Akkad
- Boers
- Brazil
- Gaul
- Finland
- Japan
- Jerusalem
- Carthagen
There is still a list that has not been included here yet, it will be in the next PR

also several fixes for 
- Granary, 
- Khambar, 
- Kampong, 
- Mead Hall, 
- Samurai, 
- Ocupada Estable

