### PR TITLE
Trireme fix penalty

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -318,8 +318,8 @@
         "requiredTech": "Sailing",
         "uniques": [
             "Cannot enter ocean tiles",
-            "Can move after attacking",
-            "[-33]% Strength <vs cities> <when attacking>"
+            "Can move after attacking"
+            //"[-33]% Strength <vs cities> <when attacking>"
         ],
         "upgradesTo": "Caravel",
         "obsoleteTech": "Astronomy",
@@ -336,8 +336,8 @@
         "requiredTech": "Sailing",
         "uniques": [
             "Cannot enter ocean tiles",
-            "Can move after attacking",
-            "[-33]% Strength <vs cities> <when attacking>"
+            "Can move after attacking"
+            //"[-33]% Strength <vs cities> <when attacking>"
         ],
         "upgradesTo": "Caravel",
         "obsoleteTech": "Astronomy",
@@ -354,8 +354,8 @@
         "requiredTech": "Sailing",
         "promotions": ["Extra Sight", "Supply"],
         "uniques": [
-            "Can move after attacking",
-            "[-33]% Strength <vs cities> <when attacking>"
+            "Can move after attacking"
+            //"[-33]% Strength <vs cities> <when attacking>"
         ],
         "upgradesTo": "Caravel",
         "obsoleteTech": "Astronomy",
@@ -369,8 +369,8 @@
         "uniques": [
             "Can move after attacking",
             "Unbuildable",
-            "Unable to pillage tiles",
-            "[-33]% Strength <vs cities> <when attacking>"
+            "Unable to pillage tiles"
+            //"[-33]% Strength <vs cities> <when attacking>"
         ],
         "upgradesTo": "Privateer",
         "attackSound": "nonmetalhit"


### PR DESCRIPTION
1. removed penalty vs cities for trireme
2. I also noticed that we don't have this penalty for Melee Water. And I do not know how to add it.
![image](https://github.com/user-attachments/assets/35973771-250b-486e-a986-8bac1aae410e)
` [-3] Movement <vs cities> <when attacking>` doesn't work when `"Can move after attacking"` enabled i quess