### PR TITLE
Catchup changes

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -505,7 +505,8 @@
         "happiness": 2,
         "uniques": [
             "Unsellable", "Unbuildable",
-            "[+2] population [in this city]"
+            "[+2] population [in this city]",
+            "Gain control over [6] tiles [in this city] <upon founding a city>"
         ]
     },
     {

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -990,7 +990,7 @@
         "faith": 3,
         "hurryCostModifier": 25,
         "uniques": [
-            "[+1 Culture] from [Strategic Resource] tiles [in this city]",
+            "[+1 Culture] from [Strategic resource] tiles [in this city]",
             "All newly-trained [relevant] units [in this city] receive the [Golden Age from Victories] promotion",
             "Destroyed when the city is captured"
         ],

--- a/jsons/Events.json
+++ b/jsons/Events.json
@@ -36,9 +36,9 @@
         ]
     },
     // Archaeology
-    {
+    /*{
         // Waiting to implement artifacts
-        /*"name": "Archaeological Dig",
+        "name": "Archaeological Dig",
         "text": "Your Archaeological Dig has uncovered an Ancient Artifact",
         "presentation": "Alert",
         "choices": [
@@ -48,7 +48,28 @@
                     "Instantly provides [1] [Artifact]"
                 ]
             }
-        ]*/
+        ]
+    },*/
+	{
+        "name": "Archaeological Dig",
+        "text": "Your Archaeological Dig has uncovered an Ancient Artifact",
+        "presentation": "Alert",
+        "choices": [
+            {
+                "text": "Dig up the Artifact",
+                "uniques": [
+                    "Instantly provides [1] [Great Work of Art]",
+                    "[This Unit] is destroyed"
+                ]
+            },
+			{
+                "text": "Convert into a permanent dig site",
+                "uniques": [
+					"Remove [Antiquity Site] resources from this tile",
+                    "[This Unit] is destroyed"
+                ]
+            }
+        ]
     },
     {
         "name": "Archaeological Dig - Hidden - Great Work of Writing",

--- a/jsons/Events.json
+++ b/jsons/Events.json
@@ -1,0 +1,520 @@
+[
+    // Spaceflight Pioneers - Great Engineer - Build Spaceship Part
+    {
+        "name": "Spaceship part",
+        "text": "By expending your [Great Engineer] you gained [spaceship parts]!",
+        "presentation": "Alert",
+        "choices": [
+            {
+                "text": "SS Booster",
+                "uniques": [
+                    "Free [SS Booster] appears <hidden from users>",
+                    "Only available <after discovering [Advanced Ballistics]> <hidden from users>"
+                ]
+            },
+            {
+                "text": "SS Cockpit",
+                "uniques": [
+                    "Free [SS Cockpit] appears <hidden from users>",
+                    "Only available <after discovering [Satellites]> <hidden from users>"
+                ]
+            },
+            {
+                "text": "SS Engine",
+                "uniques": [
+                    "Free [SS Engine] appears <hidden from users>",
+                    "Only available <after discovering [Particle Physics]> <hidden from users>"
+                ]
+            },
+            {
+                "text": "SS Stasis Chamber",
+                "uniques": [
+                    "Free [SS Stasis Chamber] appears <hidden from users>",
+                    "Only available <after discovering [Nanotechnology]> <hidden from users>"
+                ]
+            }
+        ]
+    },
+    // Archaeology
+    {
+        // Waiting to implement artifacts
+        /*"name": "Archaeological Dig",
+        "text": "Your Archaeological Dig has uncovered an Ancient Artifact",
+        "presentation": "Alert",
+        "choices": [
+            {
+                "text": "Dig up the Artifact",
+                "uniques": [
+                    "Instantly provides [1] [Artifact]"
+                ]
+            }
+        ]*/
+    },
+    {
+        "name": "Archaeological Dig - Hidden - Great Work of Writing",
+        "text": "Your Archaeological Dig has uncovered a Great Work of Writing",
+        "presentation": "None",
+        "choices": [
+            {
+                "text": "Dig up the Great Work",
+                "uniques": [
+                    "Instantly provides [1] [Great Work of Writing]"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Archaeological Dig - Hidden - Culture",
+        "text": "Your Archaeological Dig has sparked a Cultural Renaissance",
+        "presentation": "None",
+        "choices": [
+            {
+                "text": "Begin the Renaissance",
+                "uniques": [
+                    "Free Social Policy"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Archaeological Dig - Destroy Unit",
+        "text": "[This Unit] is destroyed",
+        "presentation": "None",
+        "choices": [
+            {
+                "text": "[This Unit] is destroyed",
+                "uniques": [
+                    "[This Unit] is destroyed"
+                ]
+            }
+        ]
+    },
+    // Ideology
+    {
+        "name": "Ideology",
+        "text": "Choose an [Ideology]:",
+        "presentation": "Alert",
+        "choices": [
+            {
+                "text": "Autocracy",
+                "uniques": [
+                    "Adopt [Autocracy]",
+                    "Only available <before adopting [Autocracy]>",
+                    "Only available <before adopting [Freedom]>",
+                    "Only available <before adopting [Order]>"
+                ]
+            },
+            {
+                "text": "Freedom",
+                "uniques": [
+                    "Adopt [Freedom]",
+                    "Only available <before adopting [Autocracy]>",
+                    "Only available <before adopting [Freedom]>",
+                    "Only available <before adopting [Order]>"
+                ]
+            },
+            {
+                "text": "Order",
+                "uniques": [
+                    "Adopt [Order]",
+                    "Only available <before adopting [Autocracy]>",
+                    "Only available <before adopting [Freedom]>",
+                    "Only available <before adopting [Order]>"
+                ]
+            }
+        ]
+    },
+    // Pathfinder Native Tongue
+    // Note: limitation of not allowing the last 2 options not implemented yet
+    {
+        "name": "Native Tongue",
+        "text": "The [Pathfinder]'s [Native Tongue] allows you to choose an [Ancient ruins] benefit",
+        "presentation": "Alert",
+        "choices": [
+            {
+                "text": "Use this contact with the lost tribe to enhance your [Culture]",
+                "uniques": [
+                    "Gain [20] [Culture] <(modified by game speed)> <after turn number [15]>"
+                ]
+            },
+            {
+                "text": "Convince the lost tribe to become a Worker for your civilization.",
+                "uniques": [
+                    "Free [Worker] appears"
+                ]
+            },
+            {
+                "text": "Convince the lost tribe to become a Settler for your civilization",
+                "uniques": [
+                    "Free [Settler] appears"
+                ]
+            },
+            {
+                "text": "Convince the remaining population to join one of your cities",
+                "uniques": [
+                    "[+1] population in a random city"
+                ]
+            },
+            {
+                "text": "Trade with the lost tribe for [Gold]",
+                "uniques": [
+                    "Gain [50]-[100] [Gold] <(modified by game speed)>"
+                ]
+            },
+            {
+                "text": "Study their tools to discover a new technology",
+                "uniques": [
+                    "[1] free random researchable Tech(s) from the [Ancient era]"
+                ]
+            },
+            {
+                "text": "Use equipment around the tribe to upgrade your unit",
+                "uniques": [
+                    "[This Unit] upgrades for free including special upgrades",
+					"Only available <for [Pathfinder] units>"
+                ]
+            },
+            {
+                "text": "Study their maps of nearby territory",
+                "uniques": [
+                    "Reveal up to [All] [All] within a [5] tile radius"
+                ]
+            },
+            {
+                "text": "Study the lost tribe's religion",
+                "uniques": [
+                    "Only available <when religion is enabled>",
+                    "Gain [20] [Faith] <(modified by game speed)> <after turn number [15]>"
+                ]
+            }
+        ]
+    },
+    // Kris Swordsman: Mystic Blade
+    {
+        "name": "Mystic Blade",
+        "text": "Provides a randomly selected special promotion after the first battle",
+        "presentation": "None", // A presentation of "None" will select at random.
+        "choices": [
+            {
+                "text": "Invulnerability",
+                "uniques": ["[This Unit] gains the [Invulnerability] promotion"]
+            },
+            {
+                "text": "Sneak Attack",
+                "uniques": ["[This Unit] gains the [Sneak Attack] promotion"]
+            },
+            {
+                "text": "Heroism",
+                "uniques": ["[This Unit] gains the [Heroism] promotion"]
+            },
+            {
+                "text": "Ambition",
+                "uniques": ["[This Unit] gains the [Ambition] promotion"]
+            },
+            {
+                "text": "Restlessness",
+                "uniques": ["[This Unit] gains the [Restlessness] promotion"]
+            },
+            {
+                "text": "Recruitment",
+                "uniques": ["[This Unit] gains the [Recruitment] promotion"]
+            },
+            {
+                "text": "Enemy Blade",
+                "uniques": ["[This Unit] gains the [Enemy Blade] promotion"]
+            },
+            {
+                "text": "Evil Spirits",
+                "uniques": ["[This Unit] gains the [Evil Spirits] promotion"]
+            }
+        ]
+    }
+    // Terracotta Army - Disabling temporarily until I find a solution I like better than listing every unit
+    /*{
+		"name": "Terracotta Army - Melee",
+		"text": "Terracotta Army",
+		"presentation": "Alert",
+		"choices": [
+			{
+				"text": "Warrior",
+				"uniques": [
+					"Only available <when number of [[Warrior] Units] is more than [0]>",
+					"Free [Warrior] appears"
+				]
+			},
+			{
+				"text": "Spearman",
+				"uniques": [
+					"Only available <when number of [[Spearman] Units] is more than [0]>",
+					"Free [Spearman] appears"
+				]
+			},
+			{
+				"text": "Swordsman",
+				"uniques": [
+					"Only available <when number of [[Swordsman] Units] is more than [0]>",
+					"Free [Swordsman] appears"
+				]
+			},
+			{
+				"text": "Longswordsman",
+				"uniques": [
+					"Only available <when number of [[Longswordsman] Units] is more than [0]>",
+					"Free [Longswordsman] appears"
+				]
+			},
+			{
+				"text": "Pikeman",
+				"uniques": [
+					"Only available <when number of [[Pikeman] Units] is more than [0]>",
+					"Free [Pikeman] appears"
+				]
+			},
+			{
+				"text": "Future Soldier",
+				"uniques": [
+					"Only available <when number of [[Future Soldier] Units] is more than [0]>",
+					"Free [Future Soldier] appears"
+				]
+			}
+		]
+	},
+	{
+		"name": "Terracotta Army - Archery",
+		"text": "Terracotta Army",
+		"presentation": "Alert",
+		"choices": [
+			{
+				"text": "Archer",
+				"uniques": [
+					"Only available <when number of [[Archer] Units] is more than [0]>",
+					"Free [Archer] appears"
+				]
+			},
+			{
+				"text": "Chariot Archer",
+				"uniques": [
+					"Only available <when number of [[Chariot Archer] Units] is more than [0]>",
+					"Free [Chariot Archer] appears"
+				]
+			},
+			{
+				"text": "Composite Bowman",
+				"uniques": [
+					"Only available <when number of [[Composite Bowman] Units] is more than [0]>",
+					"Free [Composite Bowman] appears"
+				]
+			},
+			{
+				"text": "Crossbowman",
+				"uniques": [
+					"Only available <when number of [[Crossbowman] Units] is more than [0]>",
+					"Free [Crossbowman] appears"
+				]
+			},
+			{
+				"text": "Gatling Gun",
+				"uniques": [
+					"Only available <when number of [[Gatling Gun] Units] is more than [0]>",
+					"Free [Gatling Gun] appears"
+				]
+			},
+			{
+				"text": "Machine Gun",
+				"uniques": [
+					"Only available <when number of [[Machine Gun] Units] is more than [0]>",
+					"Free [Machine Gun] appears"
+				]
+			},
+			{
+				"text": "Bazooka",
+				"uniques": [
+					"Only available <when number of [[Bazooka] Units] is more than [0]>",
+					"Free [Bazooka] appears"
+				]
+			}
+		]
+	},
+	{
+		"name": "Terracotta Army - Mounted",
+		"text": "Terracotta Army",
+		"presentation": "Alert",
+		"choices": [
+			{
+				"text": "Horseman",
+				"uniques": [
+					"Only available <when number of [[Horseman] Units] is more than [0]>",
+					"Free [Horseman] appears"
+				]
+			},
+			{
+				"text": "Knight",
+				"uniques": [
+					"Only available <when number of [[Knight] Units] is more than [0]>",
+					"Free [Knight] appears"
+				]
+			},
+			{
+				"text": "Lancer",
+				"uniques": [
+					"Only available <when number of [[Lancer] Units] is more than [0]>",
+					"Free [Lancer] appears"
+				]
+			},
+			{
+				"text": "Cavalry",
+				"uniques": [
+					"Only available <when number of [[Cavalry] Units] is more than [0]>",
+					"Free [Cavalry] appears"
+				]
+			}
+		]
+	},
+	{
+		"name": "Terracotta Army - Siege",
+		"text": "Terracotta Army",
+		"presentation": "Alert",
+		"choices": [
+			{
+				"text": "Catapult",
+				"uniques": [
+					"Only available <when number of [[Catapult] Units] is more than [0]>",
+					"Free [Catapult] appears"
+				]
+			},
+			{
+				"text": "Trebuchet",
+				"uniques": [
+					"Only available <when number of [[Trebuchet] Units] is more than [0]>",
+					"Free [Trebuchet] appears"
+				]
+			},
+			{
+				"text": "Cannon",
+				"uniques": [
+					"Only available <when number of [[Cannon] Units] is more than [0]>",
+					"Free [Cannon] appears"
+				]
+			},
+			{
+				"text": "Artillery",
+				"uniques": [
+					"Only available <when number of [[Artillery] Units] is more than [0]>",
+					"Free [Artillery] appears"
+				]
+			},
+			{
+				"text": "Rocket Artillery",
+				"uniques": [
+					"Only available <when number of [[Rocket Artillery] Units] is more than [0]>",
+					"Free [Rocket Artillery] appears"
+				]
+			}
+		]
+	},
+	{
+		"name": "Terracotta Army - Gunpowder",
+		"text": "Terracotta Army",
+		"presentation": "Alert",
+		"choices": [
+			{
+				"text": "Musketman",
+				"uniques": [
+					"Only available <when number of [[Musketman] Units] is more than [0]>",
+					"Free [Musketman] appears"
+				]
+			},
+			{
+				"text": "Rifleman",
+				"uniques": [
+					"Only available <when number of [[Rifleman] Units] is more than [0]>",
+					"Free [Rifleman] appears"
+				]
+			},
+			{
+				"text": "Anti-Aircraft Gun",
+				"uniques": [
+					"Only available <when number of [[Anti-Aircraft Gun] Units] is more than [0]>",
+					"Free [Anti-Aircraft Gun] appears"
+				]
+			},
+			{
+				"text": "Great War Infantry",
+				"uniques": [
+					"Only available <when number of [[Great War Infantry] Units] is more than [0]>",
+					"Free [Great War Infantry] appears"
+				]
+			},
+			{
+				"text": "Infantry",
+				"uniques": [
+					"Only available <when number of [[Infantry] Units] is more than [0]>",
+					"Free [Infantry] appears"
+				]
+			},
+			{
+				"text": "Anti-Tank Gun",
+				"uniques": [
+					"Only available <when number of [[Anti-Tank Gun] Units] is more than [0]>",
+					"Free [Anti-Tank Gun] appears"
+				]
+			},
+			{
+				"text": "Marine",
+				"uniques": [
+					"Only available <when number of [[Marine] Units] is more than [0]>",
+					"Free [Marine] appears"
+				]
+			},
+			{
+				"text": "Paratrooper",
+				"uniques": [
+					"Only available <when number of [[Paratrooper] Units] is more than [0]>",
+					"Free [Paratrooper] appears"
+				]
+			},
+			{
+				"text": "Mobile SAM",
+				"uniques": [
+					"Only available <when number of [[Mobile SAM] Units] is more than [0]>",
+					"Free [Mobile SAM] appears"
+				]
+			}
+		]
+	},
+	{
+		"name": "Terracotta Army - Armored",
+		"text": "Terracotta Army",
+		"presentation": "Alert",
+		"choices": [
+			{
+				"text": "Tank",
+				"uniques": [
+					"Only available <when number of [[Tank] Units] is more than [0]>",
+					"Free [Tank] appears"
+				]
+			},
+			{
+				"text": "Mechanized Infantry",
+				"uniques": [
+					"Only available <when number of [[Mechanized Infantry] Units] is more than [0]>",
+					"Free [Mechanized Infantry] appears"
+				]
+			},
+			{
+				"text": "Modern Armor",
+				"uniques": [
+					"Only available <when number of [[Modern Armor] Units] is more than [0]>",
+					"Free [Modern Armor] appears"
+				]
+			},
+			{
+				"text": "Giant Death Robot",
+				"uniques": [
+					"Only available <when number of [[Giant Death Robot] Units] is more than [0]>",
+					"Free [Giant Death Robot] appears"
+				]
+			}
+		]
+	}*/
+]

--- a/jsons/Events.json
+++ b/jsons/Events.json
@@ -99,6 +99,7 @@
                 "text": "Autocracy",
                 "uniques": [
                     "Adopt [Autocracy]",
+					"Triggers a [Choose Autocracy] event <hidden from users>",
                     "Only available <before adopting [Autocracy]>",
                     "Only available <before adopting [Freedom]>",
                     "Only available <before adopting [Order]>"
@@ -108,6 +109,7 @@
                 "text": "Freedom",
                 "uniques": [
                     "Adopt [Freedom]",
+					"Triggers a [Choose Freedom] event <hidden from users>",
                     "Only available <before adopting [Autocracy]>",
                     "Only available <before adopting [Freedom]>",
                     "Only available <before adopting [Order]>"
@@ -117,9 +119,223 @@
                 "text": "Order",
                 "uniques": [
                     "Adopt [Order]",
+					"Triggers a [Choose Order] event <hidden from users>",
                     "Only available <before adopting [Autocracy]>",
                     "Only available <before adopting [Freedom]>",
                     "Only available <before adopting [Order]>"
+                ]
+            }
+        ]
+    },
+	{
+        "name": "Choose Order",
+        "text": "Choose an [Order] policy:",
+        "presentation": "Alert",
+        "choices": [
+            {
+                "text": "Hero of the People",
+                "uniques": [
+                    "Adopt [Hero of the People]",
+					"Comment [[+20]% Great Person generation [in all cities]]",
+					"Only available <before adopting [Hero of the People]>"
+                ]
+            },
+            {
+                "text": "Socialist Realism",
+                "uniques": [
+                    "Adopt [Socialist Realism]",
+                    "Comment [[+2 Happiness] from every [Monument]]",
+                    "Comment [[+100]% Production when constructing [Monument] buildings [in all cities]]",
+					"Only available <before adopting [Socialist Realism]>"
+                ]
+            },
+            {
+                "text": "Patriotic War",
+                "uniques": [
+                    "Adopt [Patriotic War]",
+                    "Comment [[[+10]% Strength] [for [Military] units] [when fighting in [Friendly Land] tiles]]",
+                    "Comment [[[+50]% XP gained from combat] [for [non-[Air]] units]]",
+					"Only available <before adopting [Patriotic War]>"
+                ]
+            },
+            {
+                "text": "Double Agents",
+                "uniques": [
+                    "Adopt [Double Agents]",
+                    "Comment [[-100]% enemy spy effectiveness [in all cities connected to capital]]",
+					"Only available <before adopting [Double Agents]>"
+                ]
+            },
+            {
+                "text": "Young Pioneers",
+                "uniques": [
+                    "Adopt [Young Pioneers]",
+                    "Comment [[+1 Happiness] from every [Workshop]]",
+                    "Comment [[+1 Happiness] from every [Factory]]",
+                    "Comment [[+1 Happiness] from every [Solar Plant]]",
+                    "Comment [[+1 Happiness] from every [Nuclear Plant]]",
+                    "Comment [[+1 Happiness] from every [Hydro Plant]]",
+					"Only available <before adopting [Young Pioneers]>"
+                ]
+            },
+            {
+                "text": "Party Leadership",
+                "uniques": [
+                    "Adopt [Party Leadership]",
+                    "Comment [[+2 Food, +2 Gold, +1 Production, +1 Science] [in all cities]]",
+					"Only available <before adopting [Party Leadership]>"
+                ]
+            },
+            {
+                "text": "Resettlements",
+                "uniques": [
+                    "Adopt [Resettlements]",
+                    "Comment [[[+4] population [in this city]] [upon founding a city]]",
+                    "Comment [[Gain a free [Workshop] [in this city]] [upon founding a city]]",
+                    "Comment [[Gain a free [Monument] [in this city]] [upon founding a city]]",
+                    "Comment [[Gain a free [Granary] [in this city]] [upon founding a city]]",
+                    "Comment [[Gain a free [Library] [in this city]] [upon founding a city]]",
+                    "Comment [[Gain a free [Aqueduct] [in this city]] [upon founding a city]]",
+					"Only available <before adopting [Resettlements]>"
+                ]
+            }
+        ]
+    },
+	{
+        "name": "Choose Freedom",
+        "text": "Choose an [Freedom] policy:",
+        "presentation": "Alert",
+        "choices": [
+            {
+                "text": "Avant Garde",
+                "uniques": [
+                    "Adopt [Avant Garde]",
+                    "Comment [[+25]% Great Person generation [in all cities]]",
+					"Only available <before adopting [Avant Garde]>"
+                ]
+            },
+            {
+                "text": "Creative Expression",
+                "uniques": [
+                    "Adopt [Creative Expression]",
+                    "Comment [[+2 Culture] from every [Great Work]]",
+					"Only available <before adopting [Creative Expression]>"
+                ]
+            },
+            {
+                "text": "Civil Society",
+                "uniques": [
+                    "Adopt [Civil Society]",
+                    "Comment [[-50]% Food consumption by specialists [in all cities]]",
+					"Only available <before adopting [Civil Society]>"
+                ]
+            },
+            {
+                "text": "Volunteer Army",
+                "uniques": [
+                    "Adopt [Volunteer Army]",
+                    "Comment [[3] free [Foreign Legion] units appear]",
+                    "Comment [[3] units cost no maintenance]",
+                    "Comment [[Gunpowder] units gain the [Morale] promotion]",
+                    "Comment [All newly-trained [Gunpowder] units [in all cities] receive the [Morale] promotion]",
+					"Only available <before adopting [Volunteer Army]>"
+                ]
+            },
+            {
+                "text": "Covert Action",
+                "uniques": [
+                    "Adopt [Covert Action]",
+                    "Comment [[+100]% spy effectiveness [in City-State cities]]",
+                    "Comment [Gain an extra spy]",
+					"Only available <before adopting [Covert Action]>"
+                ]
+            },
+            {
+                "text": "Capitalism",
+                "uniques": [
+                    "Adopt [Capitalism]",
+                    "Comment [[+1 Happiness] from every [Market]]",
+                    "Comment [[+1 Happiness] from every [Bank]]",
+                    "Comment [[+1 Happiness] from every [Stock Exchange]]",
+					"Only available <before adopting [Capitalism]>"
+                ]
+            },
+            {
+                "text": "Economic Union",
+                "uniques": [
+                    "Adopt [Economic Union]",
+                    "Comment [[+25]% [Gold] [in all cities]]",
+                    "Comment [Provides [1] [Trade Route]]",
+					"Only available <before adopting [Economic Union]>"
+                ]
+            }
+        ]
+    },
+	{
+        "name": "Choose Autocracy",
+        "text": "Choose an [Autocracy] policy:",
+        "presentation": "Alert",
+        "choices": [
+            {
+                "text": "Elite Forces",
+                "uniques": [
+                    "Adopt [Elite Forces]",
+                    "Comment [[[+10]% Strength] [for [Military] units]]",
+                    "Comment [[[+10] HP when healing] [for [Military] units]]",
+					"Only available <before adopting [Elite Forces]>"
+                ]
+            },
+            {
+                "text": "Mobilization",
+                "uniques": [
+                    "Adopt [Mobilization]",
+                    "Comment [[Gold] cost of purchasing [All] units [-25]%]",
+                    "Comment [[[-25]% maintenance costs] [for [All] units]]",
+					"Only available <before adopting [Mobilization]>"
+                ]
+            },
+            {
+                "text": "United Front",
+                "uniques": [
+                    "Adopt [United Front]",
+                    "Comment [Militaristic City-States grant units [2] times as fast when you are at war with a common nation]",
+					"Only available <before adopting [United Front]>"
+                ]
+            },
+            {
+                "text": "Futurism",
+                "uniques": [
+                    "Adopt [Futurism]",
+                    "Comment [[Gain [250] [Culture]] [(modified by game speed)] [upon gaining a [Great Artist] unit]]",
+                    "Comment [[Gain [250] [Culture]] [(modified by game speed)] [upon gaining a [Great Writer] unit]]",
+                    "Comment [[Gain [250] [Culture]] [(modified by game speed)] [upon gaining a [Great Musician] unit]]",
+					"Only available <before adopting [Futurism]>"
+                ]
+            },
+            {
+                "text": "Industrial Espionage",
+                "uniques": [
+                    "Adopt [Industrial Espionage]",
+                    "Comment [[+100]% spy effectiveness [in all cities]]",
+					"Only available <before adopting [Industrial Espionage]>"
+                ]
+            },
+            {
+                "text": "Militarism",
+                "uniques": [
+                    "Adopt [Militarism]",
+                    "Comment [[+1 Happiness] from every [Barracks]]",
+                    "Comment [[+1 Happiness] from every [Armory]]",
+                    "Comment [[+1 Happiness] from every [Military Academy]]",
+					"Only available <before adopting [Militarism]>"
+                ]
+            },
+            {
+                "text": "Fascism",
+                "uniques": [
+                    "Adopt [Fascism]",
+                    "Comment [[+12 Happiness]]",
+					"Only available <before adopting [Fascism]>"
                 ]
             }
         ]
@@ -218,14 +434,6 @@
             {
                 "text": "Recruitment",
                 "uniques": ["[This Unit] gains the [Recruitment] promotion"]
-            },
-            {
-                "text": "Enemy Blade",
-                "uniques": ["[This Unit] gains the [Enemy Blade] promotion"]
-            },
-            {
-                "text": "Evil Spirits",
-                "uniques": ["[This Unit] gains the [Evil Spirits] promotion"]
             }
         ]
     }

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -2728,7 +2728,10 @@
         "outerColor": [65,54,42],
         "innerColor": [78,244,234],
         "uniqueName": "Great Expanse",
-        "uniques": ["[+15]% Strength <for [Military] units> <in [Friendly Land] tiles>"],
+        "uniques": [
+            "[+15]% Strength <for [Military] units> <in [Friendly Land] tiles>",
+            "Gain control over [4] tiles [in this city] <upon founding a city>"
+        ],
         "cities": [
             "Moson Kahni","Te-Moak","Agaidika","Goshute","Pohokwi","Washakie","Timbisha","Hukandeka","Duckwater","Tukudeka",
             "Kuchundeka","Yomba","Kamudeka","Ely","Yambadeka","Nampa","Bannock","Yahandeka","Tetadeka","Deheyaeka",

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -1406,7 +1406,13 @@
         "name": "Ideology",
         "era": "Modern era",
         "uniques": [
-            "Free Social Policy",
+            "Comment [Choose an [Ideology] upon reaching the [Modern era], or owning 3 [Factory] buildings]",
+			// Humans are given an event to choose their Ideology.
+            // AI will instead choose via the free policy once it's implemented correctly (sorry, I'm being lazy about adding it)
+
+			"Triggers a [Ideology] event <for [Human player] Civilizations> <hidden from users>",
+            "Triggers a [Ideology] event <for [AI player] Civilizations> <hidden from users>",
+			//"Free Social Policy <for [AI player] Civilizations> <hidden from users>",
             "Unavailable"
         ],
         "policies": [

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -1019,7 +1019,7 @@
             {
                 "name": "Covert Action",
                 "uniques": [
-                    "[+100]% spy effectiveness [City-States]",
+                    "[+100]% spy effectiveness [in City-State cities]",
                     //Unique for rigging elections
                     "Gain an extra spy",
                     "Provides [1] [Level 1 Ideology]",

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -1228,6 +1228,7 @@
             {
                 "name": "Futurism",
                 "uniques": [
+                    // Should be Tourism
                     "Gain [250] [Culture] <(modified by game speed)> <upon gaining a [Great Artist] unit>",
                     "Gain [250] [Culture] <(modified by game speed)> <upon gaining a [Great Writer] unit>",
                     "Gain [250] [Culture] <(modified by game speed)> <upon gaining a [Great Musician] unit>",

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -747,7 +747,6 @@
         "name": "Order",
         "era": "Ancient era",
         "uniques": [
-            "Free Social Policy",
             "Comment [Unlocks [Kremlin]]",
             "Only available <before adopting [Autocracy]>",
             "Only available <before adopting [Freedom]>",
@@ -966,7 +965,6 @@
         "name": "Freedom",
         "era": "Ancient era",
         "uniques": [
-            "Free Social Policy",
             "Comment [Unlocks [Statue of Liberty]]",
             "Only available <before adopting [Autocracy]>",
             "Only available <before adopting [Order]>",
@@ -1189,7 +1187,6 @@
         "name": "Autocracy",
         "era": "Ancient era",
         "uniques": [
-            "Free Social Policy",
             "Comment [Unlocks [Prora]]",
             "Only available <before adopting [Order]>",
             "Only available <before adopting [Freedom]>",

--- a/jsons/Ruins.json
+++ b/jsons/Ruins.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "freeCulture",
-        "notification": "We have discovered cultural artifacts in the ruins! (+10 culture)",
+        "notification": "We have discovered cultural artifacts in the ruins!",
         "uniques": ["Gain [20] [Culture] <(modified by game speed)> <after turn number [15]>"]
         },
     {
@@ -42,7 +42,7 @@
     {
         "name": "crudelyDrawnMap",
         "notification": "We have found a crudely-drawn map in the ruins!",
-        "uniques": ["Reveal up to [All] [All] within a [6] tile radius"]
+        "uniques": ["Reveal up to [All] [All] within a [5] tile radius"]
         },
     {
         "name": "holySymbols",

--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -197,10 +197,12 @@
     {
         "name": "Archaeological Dig",
         "terrainsCanBeBuiltOn": ["Plains","Grassland","Desert","Hill","Tundra","Forest","Jungle","Flood plains","Marsh","Snow"],
+		"turnsToBuild": 4,
         "culture": 6,
         "gold": 2,
         "science": 2,
         "uniques": [
+			"Triggers a [Archaeological Dig] event <in [Antiquity Site] tiles>",
             "Can be built outside your borders",
             "Can only be built to improve a resource",
             "Removes removable features when built",

--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -135,6 +135,65 @@
     },
 
     // Special improvement
+    /*// Archeology
+	// https://civilization.fandom.com/wiki/Antiquity_Site_(Civ5)
+	{
+		"name": "Landmark",
+		"terrainsCanBeBuiltOn": ["Land"],
+		"culture": 1,
+		"turnsToBuild": 4,
+		"uniques": [
+			"[+1 Culture] <for every [Era number]>", // +1 Culture for each era of difference between the era of origin of the Antiquity Site and the current era
+			"Great Improvement",
+			"Can also be built on tiles adjacent to fresh water <hidden from users>",
+            "Can only be built to improve a resource <hidden from users>",
+			"Removes removable features when built <hidden from users>",
+            "Will not be replaced by automated units <hidden from users>",
+			"Remove [Antiquity Site] resources from this tile <hidden from users>",
+			"Pillaging this improvement yields approximately [+20 Gold]",
+			"Antiquity Dig Site",
+			"Only available <for [Archaeologist] units>"
+		],
+		"civilopediaText": [
+			{ "text": "Landmarks are built from [Antiquity Site]s by [Archaeologist]s, consuming the unit." },
+			{ "separator": true },
+			{ "text": "Antiquity Site", "link": "Resource/Antiquity Site" },
+			{ "text": "Archaeologist", "link": "Unit/Archaeologist" }
+		]
+	},
+	{
+		"name": "Archaeological Dig",
+        "terrainsCanBeBuiltOn": ["Land"],
+		"culture": 5,
+		"turnsToBuild": 3,
+		"techRequired": "Archaeology",
+		"uniques": [
+			"Can only be built to improve a resource",
+			"Can also be built on tiles adjacent to fresh water",
+			"Removes removable features when built",
+
+			// Antiquity Site
+			"Triggers a [Archaeological Dig] event <in [Antiquity Site] tiles>",
+
+	        // Hidden Antiquity Site: Give 30% chance in Civ 5, but we are generous.
+			"Triggers a [Archaeological Dig - Hidden - Great Work of Writing] event <in [Hidden Antiquity Site] tiles> <with [75]% chance> <hidden from users>",
+			"Triggers a [Archaeological Dig - Hidden - Culture] event <in [Hidden Antiquity Site] tiles> <with [75]% chance> <hidden from users>",
+
+			// Remove the resource/improvement.
+			"Remove [Archaeological Dig] improvements from this tile <hidden from users>",
+			"Remove [Antiquity Site] resources from this tile <hidden from users>",
+			"Remove [Hidden Antiquity Site] resources from this tile <hidden from users>",
+
+			// Remove the unit.
+			"Triggers a [Archaeological Dig - Destroy Unit] event <hidden from users>",
+
+            "Will not be replaced by automated units <hidden from users>",
+			"Can be built outside your borders",
+			"Excluded from map editor",
+			"Antiquity Dig Site",
+			"Only available <for [Archaeologist] units>"
+		]
+	},*/
     {
         "name": "Archaeological Dig",
         "terrainsCanBeBuiltOn": ["Plains","Grassland","Desert","Hill","Tundra","Forest","Jungle","Flood plains","Marsh","Snow"],

--- a/jsons/TileResources.json
+++ b/jsons/TileResources.json
@@ -886,17 +886,20 @@
     {
         "name": "Nutmeg", 
         "gold": 2,
-        "resourceType": "Luxury"
+        "resourceType": "Luxury",
+        "uniques": ["Doesn't generate naturally"]
     },
     {
         "name": "Cloves", 
         "gold": 2,
-        "resourceType": "Luxury"
+        "resourceType": "Luxury",
+        "uniques": ["Doesn't generate naturally"]
     },
     {
         "name": "Pepper", 
         "gold": 2,
-        "resourceType": "Luxury"
+        "resourceType": "Luxury",
+        "uniques": ["Doesn't generate naturally"]
     },
     {
         "name": "Jewelry",
@@ -929,41 +932,80 @@
     {
         "name": "Trade Route", 
         "resourceType": "Strategic",
-        "uniques": ["Cannot be traded"]
+        "uniques": [
+            "Cannot be traded",
+			"Excluded from map editor",
+			"Doesn't generate naturally"
+        ]
     },
     {
         "name": "Factories", 
         "resourceType": "Strategic",
-        "uniques": ["Not shown on world screen","Cannot be traded"]
+        "uniques": [
+            "Not shown on world screen",
+            "Cannot be traded",
+			"Excluded from map editor",
+			"Doesn't generate naturally"
+        ]
     },
     {
         "name": "Policies", 
         "resourceType": "Strategic",
-        "uniques": ["Not shown on world screen","Cannot be traded"]
+        "uniques": [
+            "Not shown on world screen",
+            "Cannot be traded",
+			"Excluded from map editor",
+			"Doesn't generate naturally"
+        ]
     },
     {
         "name": "Level 1 Ideology", 
         "resourceType": "Strategic",
-        "uniques": ["Not shown on world screen","Cannot be traded"]
+        "uniques": [
+            "Not shown on world screen",
+            "Cannot be traded",
+			"Excluded from map editor",
+			"Doesn't generate naturally"
+        ]
     },
     {
         "name": "Level 2 Ideology", 
         "resourceType": "Strategic",
-        "uniques": ["Not shown on world screen","Cannot be traded"]
+        "uniques": [
+            "Not shown on world screen",
+            "Cannot be traded",
+			"Excluded from map editor",
+			"Doesn't generate naturally"
+        ]
     },
     {
         "name": "Great Work of Writing", 
         "resourceType": "Strategic",
-        "uniques": ["Stockpiled"]
+        "uniques": [
+            "Cannot be traded",
+			"Stockpiled",
+			"Excluded from map editor",
+			"Doesn't generate naturally"
+        ]
     },
     {
         "name": "Great Work of Art", 
         "resourceType": "Strategic",
-        "uniques": ["Stockpiled"]
+        "uniques": [
+            "Cannot be traded",
+			"Stockpiled",
+			"Excluded from map editor",
+			"Doesn't generate naturally"
+        ]
     },
     {
         "name": "Great Work of Music", 
         "resourceType": "Strategic",
-        "uniques": ["Stockpiled"]
+        "uniques": [
+            "Cannot be traded <hidden from users>",
+			"Stockpiled",
+			"Excluded from map editor",
+			"Doesn't generate naturally"
+        ]
     }
 ]

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -3198,8 +3198,10 @@
         "cost": 200,
         "requiredTech": "Archaeology",
         "uniques": [
-            "Can instantly construct a [Archaeological Dig] improvement <by consuming this unit>",
-            "Only available <if [University] is constructed>",
+			"Can build [Archaeological Dig] improvements on tiles",
+			"Only available <in cities with a [University]>",
+			"Uncapturable <hidden from users>",
+			"Unavailable <for [City-States] Civilizations> <hidden from users>",
             "Cannot be purchased"
         ]
     },

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1372,7 +1372,7 @@
         ],
         "uniques": [
             "Earn [200]% of killed [Military] unit's [Strength] as [Gold]",
-            "Only available <in cities with a [Reislauder Post]>",
+            "Only available <in cities with a [Reislaufer Post]>",
             "Cannot be purchased"
         ],
         "attackSound": "metalhit"

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1180,7 +1180,7 @@
         "requiredResource": "Iron",
         "hurryCostModifier": 20,
         "uniques": [
-            "Ignore terrain cost",
+            "Ignores terrain cost",
             "[+33]% Strength <during a Golden Age>"
         ],
         "attackSound": "metalhit"
@@ -2630,7 +2630,7 @@
         "cost": 450,
         "requiredTech": "Radar",
         "uniques": [
-            "May Paradrop up to [9] tiles from inside friendly territory",
+            "May Paradrop to [Land] tiles up to [9] tiles away <in [{Friendly} {Land}] tiles>",
             "No movement cost to pillage",
             "Never appears as a Barbarian unit"
         ],
@@ -2950,7 +2950,7 @@
         "cost": 510,
         "requiredTech": "Nanotechnology",
         "uniques": [
-            "May Paradrop up to [40] tiles from inside friendly territory",
+            "May Paradrop to [Land] tiles up to [40] tiles away <in [{Friendly} {Land}] tiles>",
             "Never appears as a Barbarian unit"
         ],
         "attackSound": "shot"


### PR DESCRIPTION
I think(?) this includes all of the updated features that have been added over the last few months. Many of the edits are directly inspired by https://github.com/RobLoach/Civ-V-Brave-New-World, and I do thank RobLoach for adding in some of the necessary features to make of this work. Do note that nothing involving tourism has been implemented as of now

New changes:
- Ideology free policies are now handled using events
- Governor's mansion and Shoshone now get free tiles when founding cities
- Archaeologists now can choose between building the improvement and getting a Great Work of Art
- Functional resources (such as counting resources) no longer spawn in any way
- Various other fixes