### PR TITLE
Fixing #363

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -510,7 +510,7 @@
         "uniques": [
             "Unsellable", "Unbuildable",
             "[+2] population [in this city]",
-            "Gain control over [6] tiles [in this city] <upon founding a city>"
+            "Gain control over [6] tiles [in this city]"
         ]
     },
     {


### PR DESCRIPTION
It seems that the \<upon founding a new city\> incorrectly scoped the governor's mansion unique to other cities (rather than the one it is contained in). Removing the conditional fixed the issue.

See https://github.com/ravignir/RekMOD/issues/363