### PR TITLE
Buffed farm production for voortrekker unit and changed Exploration comment from Louvre to Tower of Belem.

### DIFF
--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -511,7 +511,7 @@
         "uniques": [
             "[+1] Movement <for [{Military} {Water}] units>",
             "[+1] Sight <for [{Military} {Water}] units>",
-            "Comment [Unlocks [The Louvre]]",
+            "Comment [Unlocks [Tower of Belem]]",
             "Comment [Unlocks [Conquistador]]",
             "Provides [1] [Policies]"
         ],

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -2343,7 +2343,10 @@
         "strength": 50,
         "cost": 300,
         "requiredTech": "Replaceable Parts",
-        "uniques": ["Can build [Farm] improvements on tiles"],
+        "uniques": [
+            "Can build [Farm] improvements on tiles",
+            "Can build [Farm] improvements at a [+134]% rate"
+        ],
         "promotions": ["Heals Completely Upon Killing","Strong Defence"],
         "upgradesTo": "Infantry",
         "obsoleteTech": "Electronics",


### PR DESCRIPTION
The intention is for the farm buff to mirror the lekmod docs. 

"Capable of building farms in 2 turns"

 Currently it takes them 7 turns on standard speed, which becomes 3 turns with the proposed change.

These should maybe be in two separate pull requests?