### PR TITLE
Implemented Akkad and Assyria siege auras

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -25,7 +25,8 @@
         "uniqueName": "The Great Unification",
         "uniques": [
             "[+2 Happiness, +3 Culture, +1 Production] [in annexed cities]",
-            "[+2 Happiness, +3 Culture, +1 Production] [in puppeted cities]"
+            "[+2 Happiness, +3 Culture, +1 Production] [in puppeted cities]",
+            "[Great General] units gain the [Akkadian General] promotion"
         ],
         "cities": [
             "Akkad","Kish","Sippar","Nuzi","Marad","Azupiranu","Eshnunna","Tell Brak","Tell Leilan","Umma",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -25,8 +25,7 @@
         "uniqueName": "The Great Unification",
         "uniques": [
             "[+2 Happiness, +3 Culture, +1 Production] [in annexed cities]",
-            "[+2 Happiness, +3 Culture, +1 Production] [in puppeted cities]",
-            "[+15]% Strength <for [Land] units> <vs cities>"
+            "[+2 Happiness, +3 Culture, +1 Production] [in puppeted cities]"
         ],
         "cities": [
             "Akkad","Kish","Sippar","Nuzi","Marad","Azupiranu","Eshnunna","Tell Brak","Tell Leilan","Umma",

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -511,7 +511,7 @@
         "uniques": [
             "[+1] Movement <for [{Military} {Water}] units>",
             "[+1] Sight <for [{Military} {Water}] units>",
-            "Comment [Unlocks [The Louvre]]",
+            "Comment [Unlocks [Tower of Belem]]",
             "Comment [Unlocks [Conquistador]]",
             "Provides [1] [Policies]"
         ],

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -511,7 +511,7 @@
         "uniques": [
             "[+1] Movement <for [{Military} {Water}] units>",
             "[+1] Sight <for [{Military} {Water}] units>",
-            "Comment [Unlocks [Tower of Belem]]",
+            "Comment [Unlocks [The Louvre]]",
             "Comment [Unlocks [Conquistador]]",
             "Provides [1] [Policies]"
         ],

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -1402,5 +1402,29 @@
         ],
         "prerequisites": ["Pünktlichkeit"],
         "unitTypes": ["Sword","Mounted","Scout","Siege","Archery","Mounted Ranged","Armored","Gunpowder","Paratrooping","Ranged Gunpowder"]
+    },
+
+    // Siege Tower: Sapper
+	{
+		"name": "Sapper",
+		"uniques": [
+			"[+50]% Strength bonus for [{Land}] units within [2] tiles <when attacking> <vs cities>",
+			"[This Unit] loses the [Sapper] promotion <upon turn end> <in tiles not adjacent to [City center] tiles>",
+			"[This Unit] loses the [Sapper] promotion <upon turn end> <for [Trebuchet] units> <hidden from users>"
+		],
+		"civilopediaText": [
+			{
+				"text": "Siege Tower",
+				"link": "Unit/Siege Tower"
+			}
+		]
+	}
+
+    {
+        "name": "Akkadian General",
+        "uniques": [
+        "[+30]% Strength bonus for [{Military} {Land}] units within [2] tiles <vs cities>"
+        ]
     }
+
 ]

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -2343,7 +2343,10 @@
         "strength": 50,
         "cost": 300,
         "requiredTech": "Replaceable Parts",
-        "uniques": ["Can build [Farm] improvements on tiles"],
+        "uniques": [
+            "Can build [Farm] improvements on tiles",
+            "Can build [Farm] improvements at a [+134]% rate"
+        ],
         "promotions": ["Heals Completely Upon Killing","Strong Defence"],
         "upgradesTo": "Infantry",
         "obsoleteTech": "Electronics",

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -3247,6 +3247,23 @@
         "movement": 7
     },
     {
+        "name": "Akkadian Great General",
+        "uniqueTo": "Akkad",
+        "replaces": "Great General",
+        "unitType": "Civilian",
+        "uniques": [
+            "[+15]% Strength bonus for [{Military} {Land}] units within [2] tiles",
+            "[+30]% Strength bonus for [{Military} {Land}] units within [2] tiles <vs cities>",
+            "Can instantly construct a [Citadel] improvement <by consuming this unit>",
+            "Can be earned through combat <for [Land] units>",
+            "Great Person - [War]",
+            "Unbuildable",
+            "Uncapturable"
+        ],
+        "movement": 4
+    },
+
+    {
         "name": "Great Admiral",
         "unitType": "Civilian Water",
         "uniques": [

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -2344,10 +2344,7 @@
         "strength": 50,
         "cost": 300,
         "requiredTech": "Replaceable Parts",
-        "uniques": [
-            "Can build [Farm] improvements on tiles",
-            "Can build [Farm] improvements at a [+134]% rate"
-        ],
+        "uniques": ["Can build [Farm] improvements on tiles"],
         "promotions": ["Heals Completely Upon Killing","Strong Defence"],
         "upgradesTo": "Infantry",
         "obsoleteTech": "Electronics",

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -742,7 +742,7 @@
         "upgradesTo": "Trebuchet",
         "promotions": ["Cover I", "Extra Sight"],
         "uniques": [
-            "[+200]% Strength <vs cities> <when attacking>",
+            "[+150]% Strength <vs cities> <when attacking>",
             "No defensive terrain bonus",
             "Can only attack [City] units",
             "[This Unit] gains the [Sapper] promotion <upon entering a [all] tile> <in tiles adjacent to [City center] tiles>"

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -744,7 +744,8 @@
         "uniques": [
             "[+200]% Strength <vs cities> <when attacking>",
             "No defensive terrain bonus",
-            "Can only attack [City] units"
+            "Can only attack [City] units",
+            "[This Unit] gains the [Sapper] promotion <upon entering a [all] tile> <in tiles adjacent to [City center] tiles>"
         ],
         "hurryCostModifier": 20,
         "attackSound": "metalhit"
@@ -3245,22 +3246,6 @@
             "Uncapturable"
         ],
         "movement": 7
-    },
-    {
-        "name": "Akkadian Great General",
-        "uniqueTo": "Akkad",
-        "replaces": "Great General",
-        "unitType": "Civilian",
-        "uniques": [
-            "[+15]% Strength bonus for [{Military} {Land}] units within [2] tiles",
-            "[+30]% Strength bonus for [{Military} {Land}] units within [2] tiles <vs cities>",
-            "Can instantly construct a [Citadel] improvement <by consuming this unit>",
-            "Can be earned through combat <for [Land] units>",
-            "Great Person - [War]",
-            "Unbuildable",
-            "Uncapturable"
-        ],
-        "movement": 4
     },
 
     {


### PR DESCRIPTION
Also removed the global modifier for Akkadian units vs cities.

Assyrian siege tower changes copied from BNW mod.