### PR TITLE
Constabulary: +1 effective counter-intelligence spy rank

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -2579,7 +2579,8 @@
         "hurryCostModifier": 25,
         "uniques": [
             "Only available <when espionage is enabled>",
-            "[-25]% enemy spy effectiveness [in this city]"
+            "[-25]% enemy spy effectiveness [in this city]",
+            "Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Banking"
     },
@@ -2594,7 +2595,8 @@
         "percentStatBonus": {"gold": 5,"production": 5},
         "uniques": [
             "Only available <when espionage is enabled>",
-            "[-25]% enemy spy effectiveness [in this city]"
+            "[-25]% enemy spy effectiveness [in this city]",
+            "Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Machinery"
     },


### PR DESCRIPTION
## Summary
- Add LekMOD-style counter-intelligence boost to **Constabulary** and Australia's **Convict Penitentiary**: spies in that city act as though they have `[+1]` levels for `[Counter-intelligence]`.
- Keeps the existing `[-25]% enemy spy effectiveness [in this city]`.
- Requires Unciv with https://github.com/yairm210/Unciv/pull/15233 (merged).

## Test plan
- [ ] Unciv build that includes #15233 + this mod: place Constabulary, assign a counter-intel spy — effective rank is +1 vs without the building.
- [ ] Convict Penitentiary (Australia) behaves the same.
- [ ] Ruleset Validator: no errors on the new unique.