### PR TITLE
Maritime city-states: coastal start bias

### DIFF
--- a/jsons/CityStateTypes.json
+++ b/jsons/CityStateTypes.json
@@ -22,6 +22,7 @@
             "[+3 Food] [in capital]",
             "[+1 Food] [in all cities]"
         ],
+        "uniques": ["Start bias [Coast]"],
         "color": [56,255,112]
     },
     {


### PR DESCRIPTION
## Summary
- Add `Start bias [Coast]` to the **Maritime** `CityStateType`, so Maritime city-states prefer coastal starts.
- Requires Unciv ≥4.21.4 with https://github.com/yairm210/Unciv/pull/15271 (merged).

## Test plan
- [ ] Unciv ≥4.21.4 + this mod: Maritime CS start locations skew coastal more often.
- [ ] Other CS types unchanged.
- [ ] Ruleset Validator: no errors on the unique.