### PR TITLE
Cargo Ship: Ocean only after Astronomy

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -328,6 +328,7 @@
         "movement": 4,
         "cost": 100,
         "uniques": [
+            "Cannot enter ocean tiles <before discovering [Astronomy]>",
             "Can instantly construct a [Sea Trade Route (Food)] improvement <by consuming this unit> <when above [-1] [Trade Route]>",
             "Can instantly construct a [Sea Trade Route (Production)] improvement <by consuming this unit> <when above [-1] [Trade Route]>",
             "Can instantly construct a [Sea Trade Route (Gold)] improvement <by consuming this unit> <when above [-1] [Trade Route]>",


### PR DESCRIPTION
## Summary
- **Cargo Ship** was missing `Cannot enter ocean tiles <before discovering [Astronomy]>`, so it could sail Ocean before Astronomy (Work Boats already had this unique).
- Added the same unique as Work Boats: Ocean is blocked until Astronomy is researched.

## Test plan
- [ ] Before Astronomy: Cargo Ship cannot enter Ocean tiles (Coast only)
- [ ] After Astronomy: Cargo Ship can enter Ocean
- [ ] Work Boats / Trireme behavior unchanged
- [ ] Sea Trade Route actions still available on coast