### PR TITLE
Brunei: Sea Nomads heal without free Supply

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -545,11 +545,7 @@
         "innerColor": [228, 134, 228],
         "uniqueName": "Sea Nomads",
         "uniques": [
-            "Comment [-33% maintenance costs for Water units]",
-            "Comment [Water units may heal outside of friendly territory]",
-            "Comment [Water units can build Water improvements on tiles]",
-            "[Water] units gain the [Sea Nomads] promotion <hidden from users>",
-            "[Water] units gain the [Supply] promotion <hidden from users>"
+            "[Water] units gain the [Sea Nomads] promotion <hidden from users>"
         ],
         "cities": [
             "Bandar Brunei","Manila","Sulu","Cebu","Maguindanao","Sarawak","Namayan","Tondo","Ma-I","Madja-As",

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -656,6 +656,7 @@
         "name": "Sea Nomads", // Brunei
         "uniques": [
             "[-33]% maintenance costs",
+            "May heal outside of friendly territory",
             "Can build [Water] improvements on tiles"
         ]
     },


### PR DESCRIPTION
## Summary
- Brunei UA `Sea Nomads`: heal outside friendly territory is on the **Sea Nomads** promo (immediate), not via free **Supply** (late promo +15 HP).
- Dropped free Supply grant and obsolete `Comment […]` stubs already covered by the promo (`[-33]%` maintenance, heal, water improvements).

## Test plan
- [ ] Brunei water unit starts with Sea Nomads promo only (no Supply).
- [ ] Unit can heal outside friendly territory from game start.
- [ ] Maintenance −33% and water improvement build still work.
- [ ] No leftover Brunei `Comment […]` in Nations.json.
