### PR TITLE
Philippines: +1 citizen on cities 2-3

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -2475,7 +2475,7 @@
         "uniqueName": "The Good Fight",
         "uniques": [
             "[+2] Movement <for [Civilian] units> <in [your] tiles>",
-            "Comment [The first two Cities you settle (after your Capital) begin with +1 extra Citizen.]"
+            "[1] population [in this city] <upon founding a city> <when number of [Cities] is between [2] and [3]>"
         ],
         "cities": [
             "Malolos","Cavite El Viejo","San Juan del Monte","Pasig","Pateros","Tagig","Kalookan","San Pedro de Makati",


### PR DESCRIPTION
## Summary
- Philippines UA `The Good Fight`: first two cities after the capital start with +1 citizen.
- Replaces `Comment […]` with existing Unciv uniques: `[1] population [in this city] <upon founding a city> <when number of [Cities] is between [2] and [3]>`.

## Test plan
- [ ] Found capital → population unchanged by this unique.
- [ ] Found 2nd city → +1 population on founding.
- [ ] Found 3rd city → +1 population on founding.
- [ ] Found 4th+ city → no extra citizen from this unique.
