### PR TITLE
Georgia: fix Georgian Mandir and Cathedral production cost

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -252,7 +252,7 @@
         "name": "Georgian Cathedral",
         "replaces": "Cathedral",
         "uniqueTo": "Georgia",
-        "cost": 135,
+        "cost": 75,
         "culture": 5,
         "production": 2,
         "uniques": [
@@ -347,13 +347,16 @@
     },
     {
         "name": "Georgian Mandir",
+        "replaces": "Mandir",
+        "uniqueTo": "Georgia",
+        "cost": 135,
         "production": 2,
         "uniques": [
-            "Unbuildable","Unsellable",
+            "Unsellable",
             "[+1 Food, +1 Production] from [Luxury resource] tiles [in this city]",
-            "Can be purchased for [270] [Faith] [in all cities]",
             "Only available <when religion is enabled>",
-            "Only available <in cities with a [Mandirs] religion>"
+            "Only available <in cities with a [Mandirs] religion>",
+            "Will not be displayed in Civilopedia"
         ]
     },
     // Uniques


### PR DESCRIPTION
## Summary
- **Georgian Mandir** was broken: missing `replaces`/`uniqueTo`, still `Unbuildable` + Faith purchase. Align with other Georgian belief buildings: buildable with Production (135 = 50% of 270 Faith), `+2 Production`, no Faith buy.
- **Georgian Cathedral**: cost `135` → `75` (50% of Cathedral Faith cost 150).

UA remains via UU buildings; Nations `Comment […]` lines are Civilopedia text. No Unciv unique needed: Houses of Worship already has no Georgian replacements.

## Test plan
- [ ] As Georgia: Mandir appears in the Production queue (not Faith-only), cost 135.
- [ ] Georgian Cathedral cost is 75.
- [ ] Other Georgian Mosque/Pagoda/… unchanged.
- [ ] Houses of Worship buildings (Art Hall, etc.) remain Faith-only.
