### PR TITLE
Lithuania: Krivis full Great Prophet actions

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -3171,12 +3171,21 @@
         "unitType": "Civilian",
         "uniques": [
             "Can instantly construct a [Sacred Grove] improvement <by consuming this unit> <if it hasn't used other actions yet>",
+            "Can Spread Religion <for [8] movement> <[4] times> <after which this unit is consumed>",
+			"Removes other religions when spreading religion",
+            "May found a religion <by consuming this unit> <if it hasn't used other actions yet>",
+            "May enhance a religion <by consuming this unit>  <if it hasn't used other actions yet>",
+            "May enter foreign tiles without open borders",
             "Great Person - [Faith]",
-            "Uncapturable",
             "Unbuildable",
-            "Only available <when religion is enabled>"
+            "Uncapturable",
+            "Religious Unit",
+            "Only available <when religion is enabled>",
+            "[-1] Sight",
+            "Takes your religion over the one in their birth city"
         ],
-        "movement": 4
+        "movement": 4,
+        "religiousStrength": 1000
     },
     {
         "name": "Great General",


### PR DESCRIPTION
## Summary
- `Krivis` replaced Great Prophet but was missing spread / found / enhance / foreign tiles / religious strength / sight / birth-city religion.
- Restores full Great Prophet actions while keeping **Sacred Grove** (instead of Holy Site) as the consume improvement.

## Test plan
- [ ] As Lithuania, generate a Krivis (not a stock Great Prophet).
- [ ] Can spread religion, found/enhance religion, enter foreign tiles.
- [ ] Consume builds Sacred Grove (not Holy Site).
- [ ] First-Krivis −50% Faith cost workaround still works.
