### PR TITLE
Greece: City-State territory counts as friendly

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -1255,7 +1255,8 @@
         "uniqueName": "Hellenic League",
         "uniques": [
             "[-50]% City-State Influence degradation",
-            "City-State Influence recovers at twice the normal rate"
+            "City-State Influence recovers at twice the normal rate",
+            "City-State territory always counts as friendly territory"
         ],
         "cities": [
             "Athens","Sparta","Corinth","Argos","Knossos","Mycenae","Pharsalos","Ephesus","Halicarnassus","Rhodes",


### PR DESCRIPTION
## Summary
- Greece UA `Hellenic League`: add `City-State territory always counts as friendly territory`.
- Lek/Civ5 source (not Master List inference): `TRAIT_CITY_STATE_FRIENDSHIP` has `CityStateFriendshipModifier=100`. In DLL that both (1) modifies influence recover/decay and (2) makes `IsPlayerHasOpenBordersAutomatically` true for **all** City-States.
- Open Borders with a CS → `CvPlot::IsFriendlyTerritory` → friendly heal, and skips trespass influence loss (same reason `AngerFreeIntrusionOfCityStates` is false / “not needed for Greece” in the trait XML).
- Matches Unciv Vanilla / G&K Greece (RekMOD was missing the third unique). Existing influence degrade/recover uniques unchanged.

## Test plan
- [ ] As Greece, units in neutral CS territory heal as in friendly land and do not lose influence for trespass.
- [ ] Influence degrade −50% and recover 2× still work.
- [ ] Other civs unchanged (no free heal / no trespass immunity in CS land unless Friend+).