### PR TITLE
Hungary: Black Arquebusier set-up ranged attacks

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1677,11 +1677,15 @@
         "uniqueTo": "Hungary",
         "movement": 2,
         "strength": 24,
+        "rangedStrength": 24,
         "cost": 135,
         "requiredTech": "Gunpowder",
         "upgradesTo": "Rifleman",
         "promotions": ["Accuracy I"],
         "obsoleteTech": "Rifling",
+        "uniques": [
+            "Must set up to ranged attack"
+        ],
         "attackSound": "shot"
     },
     {

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1684,6 +1684,7 @@
         "promotions": ["Accuracy I"],
         "obsoleteTech": "Rifling",
         "uniques": [
+            "Can melee attack",
             "Must set up to ranged attack"
         ],
         "attackSound": "shot"


### PR DESCRIPTION
## Summary
- Black Arquebusier (Hungary UU): `rangedStrength` 24, `Can melee attack`, and `Must set up to ranged attack`.
- Matches LekMOD Master List: 24 melee and ranged, can both melee and ranged attack, must set up to ranged attack. Accuracy I was already present.
- Depends on Unciv unique `Can melee attack`: https://github.com/yairm210/Unciv/pull/15395 (cannot merge this until that Unciv change is in the game used by players).

## Test plan
- [ ] Requires an Unciv build with yairm210/Unciv#15395.
- [ ] Build Black Arquebusier as Hungary.
- [ ] Adjacent enemy: melee attack after moving; kill moves onto the tile; 1-HP cities can be captured.
- [ ] Enemy at range 2 after set-up: ranged attack, unit stays put.
- [ ] Without set-up, can still melee; ranged fire needs set-up (or leftover movement to set up in place).
- [ ] Accuracy I still present; upgrades to Rifleman as before.